### PR TITLE
Allow RDS db_user To Contain An Underscore, Increase Length Limit

### DIFF
--- a/stack/database.py
+++ b/stack/database.py
@@ -119,7 +119,7 @@ db_user = template.add_parameter(
         Description="The database admin account username",
         Type="String",
         MinLength="1",
-        MaxLength="32",
+        MaxLength="63",
         AllowedPattern="[a-zA-Z][a-zA-Z0-9_]*",
         ConstraintDescription=(
             "must begin with a letter and contain only"

--- a/stack/database.py
+++ b/stack/database.py
@@ -119,11 +119,11 @@ db_user = template.add_parameter(
         Description="The database admin account username",
         Type="String",
         MinLength="1",
-        MaxLength="16",
-        AllowedPattern="[a-zA-Z][a-zA-Z0-9]*",
+        MaxLength="32",
+        AllowedPattern="[a-zA-Z][a-zA-Z0-9_]*",
         ConstraintDescription=(
             "must begin with a letter and contain only"
-            " alphanumeric characters."
+            " alphanumeric characters and underscores."
         )
     ),
     group="Database",


### PR DESCRIPTION
Similar to https://github.com/caktus/aws-web-stacks/pull/31, this pull request makes the `db_user` pattern less restrictive, by allowing an underscore character, and making the limit twice as long. After checking with the AWS [documentation](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Limits.html), we weren’t positive if underscores are allowed, so we tried it for the new caktus website server, and succeeded. The maximum length AWS allows is 63 characters, so setting it to 32 characters is still well below the limit.