### PR TITLE
Allow (none) for CertificateValidationMethod

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,16 @@
 Change Log
 ==========
 
+
+`X.Y.Z`_ (TBD-DD-DD)
+---------------------
+
+Features:
+
+* Allow ACM certificate to be optional and/or be specified at a later date via a manual process. See
+  Manual ACM Certificates in README for more information.
+
+
 `1.3.0`_ (2018-09-13)
 ---------------------
 

--- a/README.rst
+++ b/README.rst
@@ -128,6 +128,32 @@ query) and follow the link to approve the certificate. If you're using a ``.io``
 may be necessary to receive email for ``.io`` domains, because domain owner emails cannot
 be discovered via ``whois``.
 
+Manual ACM Certificates
+~~~~~~~~~~~~~~~~~~~~~~~
+
+You also have the option to *not* create a certificate as part of the stack provisioning process. If
+you do this, an HTTPS listener (and corresponding certificate) can be manually attached to the load
+balancer after stack creation via the AWS Console or using ``awscli`` using the steps below.
+
+To request a new certificate using DNS validation, run the following command with ``--domain-name``
+matching your desired domain::
+
+  aws acm request-certificate --domain-name [DOMAIN NAME] --validation-method DNS
+
+You can query the CNAME ``name`` and ``value`` variables using ``describe-certificate``::
+
+  aws acm list-certificates
+  aws acm describe-certificate --certificate-arn=YOUR-CertificateArn
+
+Add the listed CNAME to your DNS provider to complete the verification process.
+
+Once verified, add an HTTPS listener to the environment's ELB::
+
+  aws elb describe-load-balancers --query "LoadBalancerDescriptions[*].LoadBalancerName"
+  aws elb create-load-balancer-listeners --load-balancer-name [LB NAME]
+                                         --listeners "SSLCertificateId=[CERTIFICATE-ARN],Protocol=HTTPS,LoadBalancerPort=443,InstanceProtocol=HTTP,InstancePort=80"
+
+
 Resources Created
 -----------------
 

--- a/stack/certificates.py
+++ b/stack/certificates.py
@@ -1,9 +1,10 @@
 # Note: GovCloud doesn't support the certificate manager, so this file is
 # only imported from load_balancer.py when we're not using GovCloud.
 
-from troposphere import If, Ref
+from troposphere import If, Ref, Equals, Not
 from troposphere.certificatemanager import Certificate, DomainValidationOption
 
+from .common import dont_create_value
 from .domain import domain_name, domain_name_alternates, no_alt_domains
 from .template import template
 from .utils import ParameterWithDefaults as Parameter
@@ -12,7 +13,7 @@ certificate_validation_method = template.add_parameter(
     Parameter(
         title="CertificateValidationMethod",
         Default="DNS",
-        AllowedValues=['DNS', 'Email'],
+        AllowedValues=[dont_create_value, 'DNS', 'Email'],
         Type='String',
         Description=""
         "How to validate domain ownership for issuing an SSL certificate - "
@@ -23,9 +24,14 @@ certificate_validation_method = template.add_parameter(
     label="Certificate Validation Method"
 )
 
+cert_condition = "CertificateCondition"
+template.add_condition(cert_condition,
+                       Not(Equals(Ref(certificate_validation_method), dont_create_value)))
+
 application = Ref(template.add_resource(
     Certificate(
         'Certificate',
+        Condition=cert_condition,
         DomainName=domain_name,
         SubjectAlternativeNames=If(no_alt_domains, Ref("AWS::NoValue"), domain_name_alternates),
         DomainValidationOptions=[

--- a/stack/certificates.py
+++ b/stack/certificates.py
@@ -1,7 +1,7 @@
 # Note: GovCloud doesn't support the certificate manager, so this file is
 # only imported from load_balancer.py when we're not using GovCloud.
 
-from troposphere import If, Ref, Equals, Not
+from troposphere import Equals, If, Not, Ref
 from troposphere.certificatemanager import Certificate, DomainValidationOption
 
 from .common import dont_create_value

--- a/stack/certificates.py
+++ b/stack/certificates.py
@@ -17,8 +17,10 @@ certificate_validation_method = template.add_parameter(
         Type='String',
         Description=""
         "How to validate domain ownership for issuing an SSL certificate - "
-        "highly recommend DNS. Either way, stack creation will pause until "
-        "you do something to complete the validation."
+        "highly recommend DNS. DNS and Email will pause stack creation until "
+        "you do something to complete the validation. If omitted, an HTTPS "
+        "listener can be manually attached to the load balancer after stack "
+        "creation."
     ),
     group="Global",
     label="Certificate Validation Method"

--- a/stack/load_balancer.py
+++ b/stack/load_balancer.py
@@ -106,14 +106,15 @@ if os.environ.get('USE_GOVCLOUD') == 'on':
         Protocol='TCP',
     ))
 else:
-    from .certificates import application, cert_condition
+    from .certificates import application as application_certificate
+    from .certificates import cert_condition
     listeners.append(If(cert_condition, elb.Listener(
         Condition=cert_condition,
         LoadBalancerPort=443,
         InstanceProtocol=web_worker_protocol,
         InstancePort=web_worker_port,
         Protocol='HTTPS',
-        SSLCertificateId=application,
+        SSLCertificateId=application_certificate,
     ), Ref("AWS::NoValue")))
 
 load_balancer = elb.LoadBalancer(


### PR DESCRIPTION
Support option to manage SSL certificates outside of stack creation workflow.