### PR TITLE
Add bastion host or VPN server to the stack when a NAT gateway is used

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -56,6 +56,8 @@ Features:
 * The CloudFront distribution linked to the S3 assets bucket can now be disabled / enabled at the
   time a stack is created or updated; the CloudFront distribution now supports a custom domain name
   and SSL certificate. See: PR #30
+* You now have the option of creating a bastion host or VPN server as part of the stack, when a
+  stack with a NAT Gateway is used, to facilitate secure remote access to hosts within the VPC.
 
 
 `1.2.0`_ (2017-09-27)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,7 +22,8 @@ What's new in 1.5.0:
 * Change generated template output from JSON to YAML (thanks @cchurch)
 * Add required DBParameterGroup by default, which allows configuring database specific parameters. This avoids having to reboot a production database instance to add a DBParameterGroup in the future. (thanks @cchurch)
 * Add tags to all resources, including a common ``aws-web-stacks:stack-name`` tag with the stack's name
-
+* You now have the option of creating a bastion host or VPN server as part of the stack, when a
+  stack with a NAT Gateway is used, to facilitate secure remote access to hosts within the VPC.
 
 `1.4.0`_ (2019-08-05)
 ---------------------
@@ -56,9 +57,6 @@ Features:
 * The CloudFront distribution linked to the S3 assets bucket can now be disabled / enabled at the
   time a stack is created or updated; the CloudFront distribution now supports a custom domain name
   and SSL certificate. See: PR #30
-* You now have the option of creating a bastion host or VPN server as part of the stack, when a
-  stack with a NAT Gateway is used, to facilitate secure remote access to hosts within the VPC.
-
 
 `1.2.0`_ (2017-09-27)
 ---------------------

--- a/README.rst
+++ b/README.rst
@@ -108,6 +108,10 @@ NAT Gateways
 have the added benefit of preventing network connections to EC2 instances within the VPC, but
 come at an added cost (and no free tier).
 
+If a NAT Gateway stack is selected, you'll have the option of creating a bastion host or VPN server
+in the stack, using an AMI and instance type of your choice. No ports are open by default for
+this host (you'll need to open them manually via the AWS console or API).
+
 Stack Creation Process
 ----------------------
 

--- a/README.rst
+++ b/README.rst
@@ -109,8 +109,11 @@ have the added benefit of preventing network connections to EC2 instances within
 come at an added cost (and no free tier).
 
 If a NAT Gateway stack is selected, you'll have the option of creating a bastion host or VPN server
-in the stack, using an AMI and instance type of your choice. No ports are open by default for
-this host (you'll need to open them manually via the AWS console or API).
+in the stack, using an AMI and instance type of your choice. The bastion type selected will determine which
+ports are opened by default for this host. If ``SSH``, only SSH traffic will be allowed from the IP address
+or subnet configured by the ``AdministratorIPAddress`` parameter. If ``OpenVPN``, HTTPS and SSH traffic will
+be allowed from the ``AdministratorIPAddress``, and OpenVPN UDP traffic from any address. Additional ports
+will need to be opened manually via the AWS console or API.
 
 Stack Creation Process
 ----------------------

--- a/stack/__init__.py
+++ b/stack/__init__.py
@@ -12,6 +12,9 @@ if os.environ.get('USE_GOVCLOUD') != 'on':
     # supported in this region
     from . import search  # noqa: F401
 
+if os.environ.get('USE_NAT_GATEWAY') == 'on':
+    from . import bastion  # noqa: F401
+
 if os.environ.get('USE_ECS') == 'on':
     from . import repository  # noqa: F401
     from . import cluster  # noqa: F401

--- a/stack/bastion.py
+++ b/stack/bastion.py
@@ -1,15 +1,34 @@
 import troposphere.ec2 as ec2
-from troposphere import Equals, If, Join, Not, Output, Parameter, Ref, Tags
+from troposphere import And, Condition, Equals, FindInMap, If, Join, Not, Output, Parameter, Ref, Tags
 
+from .common import dont_create_value, use_aes256_encryption
 from .template import template
 from .vpc import public_subnet, vpc
+
+
+bastion_type = template.add_parameter(
+    Parameter(
+        "BastionType",
+        Description="Type of bastion server to create. Determines the default "
+                    "security group ingress rules to create.",
+        Type="String",
+        Default=dont_create_value,
+        AllowedValues=[
+            dont_create_value,
+            "SSH",
+            "OpenVPN",
+        ],
+    ),
+    group="Bastion Server",
+    label="Type",
+)
 
 bastion_ami = template.add_parameter(
     Parameter(
         "BastionAMI",
-        Description="(Optional) Bastion or VPN server AMI in the same region as this stack",
-        Type="String",
-        Default="",
+        Description="(Optional) Bastion or VPN server AMI in the same region as this stack.",
+        Type="AWS::EC2::Image::Id",
+        Default=dont_create_value,
     ),
     group="Bastion Server",
     label="AMI",
@@ -20,6 +39,102 @@ bastion_instance_type = template.add_parameter(
         "BastionInstanceType",
         Description="(Optional) Instance type to use for bastion server.",
         Type="String",
+        AllowedValues=[
+            't3.nano',
+            't3.micro',
+            't3.small',
+            't3.medium',
+            't3.large',
+            't3.xlarge',
+            't3.2xlarge',
+            't2.nano',
+            't2.micro',
+            't2.small',
+            't2.medium',
+            't2.large',
+            't2.xlarge',
+            't2.2xlarge',
+            'm5.large',
+            'm5.xlarge',
+            'm5.2xlarge',
+            'm5.4xlarge',
+            'm5.12xlarge',
+            'm5.24xlarge',
+            'm5d.large',
+            'm5d.xlarge',
+            'm5d.2xlarge',
+            'm5d.4xlarge',
+            'm5d.12xlarge',
+            'm5d.24xlarge',
+            'm4.large',
+            'm4.xlarge',
+            'm4.2xlarge',
+            'm4.4xlarge',
+            'm4.10xlarge',
+            'm4.16xlarge',
+            'm3.medium',
+            'm3.large',
+            'm3.xlarge',
+            'm3.2xlarge',
+            'c5.large',
+            'c5.xlarge',
+            'c5.2xlarge',
+            'c5.4xlarge',
+            'c5.9xlarge',
+            'c5.18xlarge',
+            'c5d.large',
+            'c5d.xlarge',
+            'c5d.2xlarge',
+            'c5d.4xlarge',
+            'c5d.9xlarge',
+            'c5d.18xlarge',
+            'c4.large',
+            'c4.xlarge',
+            'c4.2xlarge',
+            'c4.4xlarge',
+            'c4.8xlarge',
+            'c3.large',
+            'c3.xlarge',
+            'c3.2xlarge',
+            'c3.4xlarge',
+            'c3.8xlarge',
+            'p2.xlarge',
+            'p2.8xlarge',
+            'p2.16xlarge',
+            'g2.2xlarge',
+            'g2.8xlarge',
+            'x1.16large',
+            'x1.32xlarge',
+            'r5.large',
+            'r5.xlarge',
+            'r5.2xlarge',
+            'r5.4xlarge',
+            'r5.12xlarge',
+            'r5.24xlarge',
+            'r4.large',
+            'r4.xlarge',
+            'r4.2xlarge',
+            'r4.4xlarge',
+            'r4.8xlarge',
+            'r4.16xlarge',
+            'r3.large',
+            'r3.xlarge',
+            'r3.2xlarge',
+            'r3.4xlarge',
+            'r3.8xlarge',
+            'i3.large',
+            'i3.xlarge',
+            'i3.2xlarge',
+            'i3.4xlarge',
+            'i3.8xlarge',
+            'i3.16large',
+            'd2.xlarge',
+            'd2.2xlarge',
+            'd2.4xlarge',
+            'd2.8xlarge',
+            'f1.2xlarge',
+            'f1.16xlarge',
+        ],
         Default="t2.nano",
     ),
     group="Bastion Server",
@@ -33,29 +148,103 @@ bastion_key_name = template.add_parameter(
                     "the Bastion instance. This parameter is required even if "
                     "no Bastion AMI is specified (but will be unused).",
         Type="AWS::EC2::KeyPair::KeyName",
-        ConstraintDescription="must be the name of an existing EC2 KeyPair."
+        ConstraintDescription="must be the name of an existing EC2 KeyPair.",
+        Default=dont_create_value,
     ),
     group="Bastion Server",
     label="SSH Key Name",
 )
 
-bastion_ami_set = "BastionAmiSet"
+bastion_type_set = "BastionTypeSet"
+template.add_condition(bastion_type_set, Not(Equals("", Ref(bastion_type))))
+
+bastion_type_is_openvpn_set = "BastionTypeIsOpenVPNSet"
+template.add_condition(bastion_type_is_openvpn_set, Equals("OpenVPN", Ref(bastion_type)))
+
+bastion_ami_set = "BastionAMISet"
 template.add_condition(bastion_ami_set, Not(Equals("", Ref(bastion_ami))))
+
+bastion_type_and_ami_set = "BastionTypeAndAMISet"
+template.add_condition(bastion_type_and_ami_set, And(Condition(bastion_type_set), Condition(bastion_ami_set)))
 
 bastion_security_group = ec2.SecurityGroup(
     'BastionSecurityGroup',
     template=template,
-    GroupDescription="Bastion server security group (manually add your ingress "
-                     "rules to this security group).",
+    GroupDescription="Bastion security group.",
     VpcId=Ref(vpc),
-    Condition=bastion_ami_set,
+    Condition=bastion_type_set,
+    Tags=Tags(
+        Name=Join("-", [Ref("AWS::StackName"), "bastion"]),
+    ),
+)
+
+bastion_security_group_ingress_ssh = ec2.SecurityGroupIngress(
+    'BastionSecurityGroupIngressSSH',
+    template=template,
+    GroupId=Ref(bastion_security_group),
+    IpProtocol="tcp",
+    FromPort=22,
+    ToPort=22,
+    CidrIp=Ref("AdministratorIPAddress"),
+    Description="Administrator SSH access.",
+    Condition=bastion_type_set,
+)
+
+bastion_security_group_ingress_https = ec2.SecurityGroupIngress(
+    'BastionSecurityGroupIngressHTTPS',
+    template=template,
+    GroupId=Ref(bastion_security_group),
+    IpProtocol="tcp",
+    FromPort=443,
+    ToPort=443,
+    CidrIp=Ref("AdministratorIPAddress"),
+    Description="Administrator HTTPS access.",
+    Condition=bastion_type_is_openvpn_set,
+)
+
+bastion_security_group_ingress_openvpn = ec2.SecurityGroupIngress(
+    'BastionSecurityGroupIngressOpenVPN',
+    template=template,
+    GroupId=Ref(bastion_security_group),
+    IpProtocol="udp",
+    FromPort=1194,
+    ToPort=1194,
+    CidrIp="0.0.0.0/0",
+    Description="OpenVPN Access.",
+    Condition=bastion_type_is_openvpn_set,
+)
+
+# Allow bastion full access to workers.
+container_security_group_bastion_ingress = ec2.SecurityGroupIngress(
+    'ContainerSecurityGroupBastionIngress',
+    template=template,
+    GroupId=Ref("ContainerSecurityGroup"),
+    IpProtocol='-1',
+    SourceSecurityGroupId=Ref(bastion_security_group),
+    Condition=bastion_type_set,
+)
+
+bastion_database_condition = "BastionDatabaseCondition"
+template.add_condition(bastion_database_condition, And(Condition(bastion_type_set), Condition("DatabaseCondition")))
+
+# Allow bastion access to database.
+database_security_group_bastion_ingress = ec2.SecurityGroupIngress(
+    'DatabaseSecurityGroupBastionIngress',
+    template=template,
+    GroupId=Ref("DatabaseSecurityGroup"),
+    IpProtocol="tcp",
+    FromPort=FindInMap("RdsEngineMap", Ref("DatabaseEngine"), "Port"),
+    ToPort=FindInMap("RdsEngineMap", Ref("DatabaseEngine"), "Port"),
+    SourceSecurityGroupId=Ref(bastion_security_group),
+    Description="Bastion Access",
+    Condition=bastion_database_condition,
 )
 
 # Elastic IP for Bastion instance
 bastion_eip = ec2.EIP(
-    "BastionEip",
+    "BastionEIP",
     template=template,
-    Condition=bastion_ami_set,
+    Condition=bastion_type_set,
 )
 
 bastion_instance = ec2.Instance(
@@ -63,22 +252,32 @@ bastion_instance = ec2.Instance(
     template=template,
     ImageId=Ref(bastion_ami),
     InstanceType=Ref(bastion_instance_type),
-    KeyName=If(bastion_ami_set, Ref(bastion_key_name), Ref("AWS::NoValue")),
+    KeyName=Ref(bastion_key_name),
     SecurityGroupIds=[Ref(bastion_security_group)],
     SubnetId=Ref(public_subnet),
-    Condition=bastion_ami_set,
+    BlockDeviceMappings=[
+        ec2.BlockDeviceMapping(
+            DeviceName="/dev/sda1",
+            Ebs=ec2.EBSBlockDevice(
+                VolumeType="gp2",
+                VolumeSize=8,
+                Encrypted=use_aes256_encryption,
+            ),
+        ),
+    ],
+    Condition=bastion_type_and_ami_set,
     Tags=Tags(
-        Name=Join("", [Ref("AWS::StackName"), "bastion"]),
+        Name=Join("-", [Ref("AWS::StackName"), "bastion"]),
     ),
 )
 
 # Associate the Elastic IP separately, so it doesn't change when the instance changes.
 eip_assoc = ec2.EIPAssociation(
-    "BastionEipAssociation",
+    "BastionEIPAssociation",
     template=template,
     InstanceId=Ref(bastion_instance),
     EIP=Ref(bastion_eip),
-    Condition=bastion_ami_set,
+    Condition=bastion_type_and_ami_set,
 )
 
 template.add_output([
@@ -86,6 +285,6 @@ template.add_output([
         "BastionIP",
         Description="Public IP address of Bastion instance",
         Value=Ref(bastion_eip),
-        Condition=bastion_ami_set,
+        Condition=bastion_type_set,
     ),
 ])

--- a/stack/bastion.py
+++ b/stack/bastion.py
@@ -166,13 +166,13 @@ bastion_key_name = template.add_parameter(
 )
 
 bastion_type_set = "BastionTypeSet"
-template.add_condition(bastion_type_set, Not(Equals("", Ref(bastion_type))))
+template.add_condition(bastion_type_set, Not(Equals(dont_create_value, Ref(bastion_type))))
 
 bastion_type_is_openvpn_set = "BastionTypeIsOpenVPNSet"
 template.add_condition(bastion_type_is_openvpn_set, Equals("OpenVPN", Ref(bastion_type)))
 
 bastion_ami_set = "BastionAMISet"
-template.add_condition(bastion_ami_set, Not(Equals("", Ref(bastion_ami))))
+template.add_condition(bastion_ami_set, Not(Equals(dont_create_value, Ref(bastion_ami))))
 
 bastion_type_and_ami_set = "BastionTypeAndAMISet"
 template.add_condition(bastion_type_and_ami_set, And(Condition(bastion_type_set), Condition(bastion_ami_set)))

--- a/stack/bastion.py
+++ b/stack/bastion.py
@@ -1,10 +1,20 @@
 import troposphere.ec2 as ec2
-from troposphere import And, Condition, Equals, FindInMap, If, Join, Not, Output, Parameter, Ref, Tags
+from troposphere import (
+    And,
+    Condition,
+    Equals,
+    FindInMap,
+    Join,
+    Not,
+    Output,
+    Parameter,
+    Ref,
+    Tags
+)
 
 from .common import dont_create_value, use_aes256_encryption
 from .template import template
 from .vpc import public_subnet, vpc
-
 
 bastion_type = template.add_parameter(
     Parameter(

--- a/stack/bastion.py
+++ b/stack/bastion.py
@@ -1,0 +1,83 @@
+import troposphere.ec2 as ec2
+from troposphere import Equals, Join, Not, Output, Parameter, Ref, Tags
+
+from .template import template
+from .vpc import public_subnet, vpc
+
+bastion_ami = template.add_parameter(
+    Parameter(
+        "BastionAMI",
+        Description="(Optional) Bastion or VPN server AMI in the same region as this stack",
+        Type="String",
+        Default="",
+    ),
+    group="Bastion Server",
+    label="Router AMI",
+)
+
+bastion_instance_type = template.add_parameter(
+    Parameter(
+        "BastionInstanceType",
+        Description="(Optional) Instance type to use for bastion server.",
+        Type="String",
+        Default="t2.nano",
+    ),
+    group="Bastion Server",
+    label="Instance Type",
+)
+
+bastion_key_name = template.add_parameter(
+    Parameter(
+        "BastionKeyName",
+        Description="Name of an existing EC2 KeyPair to enable SSH access to "
+                    "the Bastion instance.",
+        Type="AWS::EC2::KeyPair::KeyName",
+        ConstraintDescription="must be the name of an existing EC2 KeyPair."
+    ),
+    group="Bastion Server",
+    label="SSH Key Name",
+)
+
+bastion_ami_set = "BastionAmiSet"
+template.add_condition(bastion_ami_set, Not(Equals("", Ref(bastion_ami))))
+
+bastion_security_group = ec2.SecurityGroup(
+    'BastionSecurityGroup',
+    template=template,
+    GroupDescription="Bastion server security group (manually add your ingress "
+                     "rules to this security group).",
+    VpcId=Ref(vpc),
+    Condition=bastion_ami_set,
+)
+
+# Elastic IP for Bastion instance
+bastion_eip = template.add_resource(ec2.EIP("BastionEip"))
+
+bastion_instance = ec2.Instance(
+    "BastionInstance",
+    template=template,
+    ImageId=Ref(bastion_ami),
+    InstanceType=Ref(bastion_instance_type),
+    KeyName=Ref(bastion_key_name),
+    SecurityGroupIds=[Ref(bastion_security_group)],
+    SubnetId=Ref(public_subnet),
+    Condition=bastion_ami_set,
+    Tags=Tags(
+        Name=Join("", [Ref("AWS::StackName"), "bastion"]),
+    ),
+)
+
+# Associate the Elastic IP separately, so it doesn't change when the instance changes.
+eip_assoc = template.add_resource(ec2.EIPAssociation(
+    "BastionEipAssociation",
+    InstanceId=Ref(bastion_instance),
+    EIP=Ref(bastion_eip),
+))
+
+template.add_output([
+    Output(
+        "BastionIP",
+        Description="Public IP address of Bastion instance",
+        Value=Ref(bastion_eip),
+    ),
+])

--- a/stack/security_groups.py
+++ b/stack/security_groups.py
@@ -61,14 +61,15 @@ if os.environ.get('USE_EB') != 'on':
         SourceSecurityGroupId=Ref(load_balancer_security_group),
     ))
 
-# AdministratorAccess
-ingress_rules.append(SecurityGroupRule(
-    IpProtocol="tcp",
-    FromPort="22",
-    ToPort="22",
-    Description="Administrator SSH Access",
-    CidrIp=administrator_ip_address,
-))
+if os.environ.get('USE_NAT_GATEWAY') != 'on':
+    # Allow direct administrator access via SSH.
+    ingress_rules.append(SecurityGroupRule(
+        IpProtocol="tcp",
+        FromPort="22",
+        ToPort="22",
+        Description="Administrator SSH Access",
+        CidrIp=administrator_ip_address,
+    ))
 
 container_security_group = SecurityGroup(
     'ContainerSecurityGroup',


### PR DESCRIPTION
Rebased existing PR #48 against master, added security group configuration. 

Should support for a pfSense bastion be defined in the same template as the SSH-only bastion, or would it be better to make these two different templates?
