### PR TITLE
Add aws-web-stacks:role tag to EC2 instances.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,7 @@ What's new in 1.5.0:
 * Change generated template output from JSON to YAML (thanks @cchurch)
 * Add required DBParameterGroup by default, which allows configuring database specific parameters. This avoids having to reboot a production database instance to add a DBParameterGroup in the future. (thanks @cchurch)
 * Add tags to all resources, including a common ``aws-web-stacks:stack-name`` tag with the stack's name
+* Add a ``aws-web-stacks:role`` tag to EC2 instances to identify as bastion vs. worker.
 * You now have the option of creating a bastion host or VPN server as part of the stack, when a
   stack with a NAT Gateway is used, to facilitate secure remote access to hosts within the VPC.
 

--- a/stack/bastion.py
+++ b/stack/bastion.py
@@ -276,9 +276,16 @@ bastion_instance = ec2.Instance(
         ),
     ],
     Condition=bastion_type_and_ami_set,
-    Tags=Tags(
-        Name=Join("-", [Ref("AWS::StackName"), "bastion"]),
-    ),
+    Tags=[
+        {
+            "Key": "Name",
+            "Value": Join("-", [Ref("AWS::StackName"), "bastion"]),
+        },
+        {
+            "Key": "aws-web-stacks:role",
+            "Value": "bastion",
+        },
+    ],
 )
 
 # Associate the Elastic IP separately, so it doesn't change when the instance changes.

--- a/stack/instances.py
+++ b/stack/instances.py
@@ -137,6 +137,11 @@ autoscaling_group = autoscaling.AutoScalingGroup(
             "Key": "Name",
             "Value": Join("-", [Ref(AWS_STACK_NAME), "web_worker"]),
             "PropagateAtLaunch": True,
-        }
+        },
+        {
+            "Key": "aws-web-stacks:role",
+            "Value": "worker",
+            "PropagateAtLaunch": True,
+        },
     ],
 )


### PR DESCRIPTION
Add ``aws-web-stacks:role`` tag to allow for identifying instances within a stack as bastion vs. worker.