### PR TITLE
Don't set PublicRead on the assets bucket

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,7 @@ What's new in 1.5.0:
 * Add a ``aws-web-stacks:role`` tag to EC2 instances to identify as bastion vs. worker.
 * You now have the option of creating a bastion host or VPN server as part of the stack, when a
   stack with a NAT Gateway is used, to facilitate secure remote access to hosts within the VPC.
+* Add a parameter to specify the default canned ACL for the public assets bucket.
 
 `1.4.0`_ (2019-08-05)
 ---------------------

--- a/stack/assets.py
+++ b/stack/assets.py
@@ -40,6 +40,24 @@ from .domain import domain_name, domain_name_alternates, no_alt_domains
 from .template import template
 from .utils import ParameterWithDefaults as Parameter
 
+assets_bucket_access_control = template.add_parameter(
+    Parameter(
+        "AssetsBucketAccessControl",
+        Default="PublicRead",
+        Description="Canned ACL for the public S3 bucket. Private is recommended; it "
+                    "allows for objects to be make publicly readable, but prevents "
+                    "listing of the bucket contents.",
+        Type="String",
+        AllowedValues=[
+            "PublicRead",
+            "Private",
+        ],
+        ConstraintDescription="Must be PublicRead or Private.",
+    ),
+    group="Static Media",
+    label="Assets Bucket ACL",
+)
+
 common_bucket_conf = dict(
     BucketEncryption=BucketEncryption(
         ServerSideEncryptionConfiguration=If(
@@ -93,7 +111,7 @@ common_bucket_conf = dict(
 assets_bucket = template.add_resource(
     Bucket(
         "AssetsBucket",
-        AccessControl=Private,
+        AccessControl=Ref(assets_bucket_access_control),
         **common_bucket_conf,
     )
 )

--- a/stack/assets.py
+++ b/stack/assets.py
@@ -30,7 +30,6 @@ from troposphere.s3 import (
     CorsRules,
     Private,
     PublicAccessBlockConfiguration,
-    PublicRead,
     ServerSideEncryptionByDefault,
     ServerSideEncryptionRule,
     VersioningConfiguration
@@ -89,11 +88,12 @@ common_bucket_conf = dict(
     ),
 )
 
-# Create an S3 bucket that holds statics and media
+# Create an S3 bucket that holds statics and media. Default to private to prevent
+# public list permissions, but still allow objects to be made publicly readable.
 assets_bucket = template.add_resource(
     Bucket(
         "AssetsBucket",
-        AccessControl=PublicRead,
+        AccessControl=Private,
         **common_bucket_conf,
     )
 )


### PR DESCRIPTION
This option currently allows public listing of the bucket contents. This change prevents public listing of objects within the bucket, though they can still be made publicly readable.