### PR TITLE
simplify/refactor subnet layout (get rid of redundant "public" subnet)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,14 +8,15 @@ Change Log
 * TBD
 
 
-`1.5.0`_ (TBD)
+`2.0.0`_ (TBD)
 ---------------------
 
-**Backwards incompatible changes:**
+**Backwards-incompatible changes:**
 
 * Update RDS resource name of database to be ``DatabaseInstance`` rather than ``PostgreSQL``. While other engines were previously supported, the title within the stack still referenced PostgreSQL. **This change will force a recreation of your RDS instance.**
+* Simplify the VPC layout to have 2 public and 2 private subnets. Due to this change, **updating an existing stack is not supported.**  You'll need to create a new stack and re-deploy all services within it.
 
-What's new in 1.5.0:
+What's new in 2.0.0:
 
 * Re-purpose use_aes256_encryption flag to support encryption across S3, RDS, and RDS (thanks @dsummersl)
 * Add configurable ContainerVolumeSize to change root volume size of EC2 instances (thanks @dsummersl)
@@ -175,7 +176,7 @@ Backwards-incompatible changes:
 * Initial public release
 
 
-.. _1.5.0: https://aws-web-stacks.s3.amazonaws.com/index.html?prefix=1.5.0/
+.. _2.0.0: https://aws-web-stacks.s3.amazonaws.com/index.html?prefix=2.0.0/
 .. _1.4.0: https://aws-web-stacks.s3.amazonaws.com/index.html?prefix=1.4.0/
 .. _1.3.0: https://aws-web-stacks.s3.amazonaws.com/index.html?prefix=1.3.0/
 .. _1.2.0: https://aws-web-stacks.s3.amazonaws.com/index.html?prefix=1.2.0/

--- a/stack/bastion.py
+++ b/stack/bastion.py
@@ -14,7 +14,7 @@ from troposphere import (
 
 from .common import dont_create_value, use_aes256_encryption
 from .template import template
-from .vpc import public_subnet, vpc
+from .vpc import public_subnet_a, vpc
 
 bastion_type = template.add_parameter(
     Parameter(
@@ -264,7 +264,7 @@ bastion_instance = ec2.Instance(
     InstanceType=Ref(bastion_instance_type),
     KeyName=Ref(bastion_key_name),
     SecurityGroupIds=[Ref(bastion_security_group)],
-    SubnetId=Ref(public_subnet),
+    SubnetId=Ref(public_subnet_a),
     BlockDeviceMappings=[
         ec2.BlockDeviceMapping(
             DeviceName="/dev/sda1",

--- a/stack/cache.py
+++ b/stack/cache.py
@@ -4,10 +4,10 @@ from .common import dont_create_value
 from .template import template
 from .utils import ParameterWithDefaults as Parameter
 from .vpc import (
-    container_a_subnet,
-    container_a_subnet_cidr,
-    container_b_subnet,
-    container_b_subnet_cidr,
+    private_subnet_a,
+    private_subnet_a_cidr,
+    private_subnet_b,
+    private_subnet_b_cidr,
     vpc
 )
 
@@ -86,13 +86,13 @@ cache_security_group = ec2.SecurityGroup(
             IpProtocol="tcp",
             FromPort=If(using_redis_condition, "6379", "11211"),
             ToPort=If(using_redis_condition, "6379", "11211"),
-            CidrIp=Ref(container_a_subnet_cidr),
+            CidrIp=Ref(private_subnet_a_cidr),
         ),
         ec2.SecurityGroupRule(
             IpProtocol="tcp",
             FromPort=If(using_redis_condition, "6379", "11211"),
             ToPort=If(using_redis_condition, "6379", "11211"),
-            CidrIp=Ref(container_b_subnet_cidr),
+            CidrIp=Ref(private_subnet_b_cidr),
         ),
     ],
     Tags=Tags(
@@ -105,7 +105,7 @@ cache_subnet_group = elasticache.SubnetGroup(
     template=template,
     Description="Subnets available for the cache instance",
     Condition=cache_condition,
-    SubnetIds=[Ref(container_a_subnet), Ref(container_b_subnet)],
+    SubnetIds=[Ref(private_subnet_a), Ref(private_subnet_b)],
 )
 
 cache_cluster = elasticache.CacheCluster(

--- a/stack/cluster.py
+++ b/stack/cluster.py
@@ -34,7 +34,7 @@ from .repository import repository
 from .security_groups import container_security_group
 from .template import template
 from .utils import ParameterWithDefaults as Parameter
-from .vpc import container_a_subnet, container_b_subnet
+from .vpc import private_subnet_a, private_subnet_b
 
 web_worker_cpu = Ref(template.add_parameter(
     Parameter(
@@ -271,7 +271,7 @@ container_instance_configuration = autoscaling.LaunchConfiguration(
 autoscaling_group = autoscaling.AutoScalingGroup(
     autoscaling_group_name,
     template=template,
-    VPCZoneIdentifier=[Ref(container_a_subnet), Ref(container_b_subnet)],
+    VPCZoneIdentifier=[Ref(private_subnet_a), Ref(private_subnet_b)],
     MinSize=desired_container_instances,
     MaxSize=max_container_instances,
     DesiredCapacity=desired_container_instances,

--- a/stack/database.py
+++ b/stack/database.py
@@ -6,10 +6,10 @@ from .common import dont_create_value, use_aes256_encryption
 from .template import template
 from .utils import ParameterWithDefaults as Parameter
 from .vpc import (
-    container_a_subnet,
-    container_a_subnet_cidr,
-    container_b_subnet,
-    container_b_subnet_cidr,
+    private_subnet_a,
+    private_subnet_a_cidr,
+    private_subnet_b,
+    private_subnet_b_cidr,
     vpc
 )
 
@@ -278,13 +278,13 @@ db_security_group = ec2.SecurityGroup(
             IpProtocol="tcp",
             FromPort=FindInMap("RdsEngineMap", Ref(db_engine), "Port"),
             ToPort=FindInMap("RdsEngineMap", Ref(db_engine), "Port"),
-            CidrIp=Ref(container_a_subnet_cidr),
+            CidrIp=Ref(private_subnet_a_cidr),
         ),
         ec2.SecurityGroupRule(
             IpProtocol="tcp",
             FromPort=FindInMap("RdsEngineMap", Ref(db_engine), "Port"),
             ToPort=FindInMap("RdsEngineMap", Ref(db_engine), "Port"),
-            CidrIp=Ref(container_b_subnet_cidr),
+            CidrIp=Ref(private_subnet_b_cidr),
         ),
     ],
     Tags=Tags(
@@ -297,7 +297,7 @@ db_subnet_group = rds.DBSubnetGroup(
     template=template,
     Condition=db_condition,
     DBSubnetGroupDescription="Subnets available for the RDS DB Instance",
-    SubnetIds=[Ref(container_a_subnet), Ref(container_b_subnet)],
+    SubnetIds=[Ref(private_subnet_a), Ref(private_subnet_b)],
 )
 
 db_instance = rds.DBInstance(

--- a/stack/dokku.py
+++ b/stack/dokku.py
@@ -11,7 +11,7 @@ from .environment import environment_variables
 from .logs import logging_policy
 from .template import template
 from .utils import ParameterWithDefaults as Parameter
-from .vpc import container_a_subnet, vpc
+from .vpc import private_subnet_a, vpc
 
 key_name = template.add_parameter(
     Parameter(
@@ -164,7 +164,7 @@ ec2_instance = template.add_resource(ec2.Instance(
     KeyName=Ref(key_name),
     SecurityGroupIds=[Ref(security_group)],
     IamInstanceProfile=Ref(instance_profile),
-    SubnetId=Ref(container_a_subnet),
+    SubnetId=Ref(private_subnet_a),
     BlockDeviceMappings=[
         ec2.BlockDeviceMapping(
             DeviceName="/dev/sda1",

--- a/stack/eb.py
+++ b/stack/eb.py
@@ -22,10 +22,10 @@ from .template import template
 from .utils import ParameterWithDefaults as Parameter
 from .vpc import (
     USE_NAT_GATEWAY,
-    container_a_subnet,
-    container_b_subnet,
-    loadbalancer_a_subnet,
-    loadbalancer_b_subnet,
+    private_subnet_a,
+    private_subnet_b,
+    public_subnet_a,
+    public_subnet_b,
     vpc
 )
 
@@ -231,16 +231,16 @@ template.add_resource(Environment(
             Namespace="aws:ec2:vpc",
             OptionName="Subnets",
             Value=Join(",", [
-                Ref(container_a_subnet),
-                Ref(container_b_subnet),
+                Ref(private_subnet_a),
+                Ref(private_subnet_b),
             ]),
         ),
         OptionSettings(
             Namespace="aws:ec2:vpc",
             OptionName="ELBSubnets",
             Value=Join(",", [
-                Ref(loadbalancer_a_subnet),
-                Ref(loadbalancer_b_subnet),
+                Ref(public_subnet_a),
+                Ref(public_subnet_b),
             ]),
         ),
         # Launch config settings

--- a/stack/instances.py
+++ b/stack/instances.py
@@ -7,7 +7,7 @@ from .logs import logging_policy
 from .security_groups import container_security_group
 from .template import template
 from .utils import ParameterWithDefaults as Parameter
-from .vpc import container_a_subnet, container_b_subnet
+from .vpc import private_subnet_a, private_subnet_b
 
 ami = Ref(template.add_parameter(
     Parameter(
@@ -124,7 +124,7 @@ container_instance_configuration = autoscaling.LaunchConfiguration(
 autoscaling_group = autoscaling.AutoScalingGroup(
     autoscaling_group_name,
     template=template,
-    VPCZoneIdentifier=[Ref(container_a_subnet), Ref(container_b_subnet)],
+    VPCZoneIdentifier=[Ref(private_subnet_a), Ref(private_subnet_b)],
     MinSize=desired_container_instances,
     MaxSize=max_container_instances,
     DesiredCapacity=desired_container_instances,

--- a/stack/load_balancer.py
+++ b/stack/load_balancer.py
@@ -6,7 +6,7 @@ from troposphere import GetAtt, If, Join, Output, Ref
 from .security_groups import load_balancer_security_group
 from .template import template
 from .utils import ParameterWithDefaults as Parameter
-from .vpc import loadbalancer_a_subnet, loadbalancer_b_subnet
+from .vpc import public_subnet_a, public_subnet_b
 
 # Web worker
 
@@ -120,8 +120,8 @@ load_balancer = elb.LoadBalancer(
     'LoadBalancer',
     template=template,
     Subnets=[
-        Ref(loadbalancer_a_subnet),
-        Ref(loadbalancer_b_subnet),
+        Ref(public_subnet_a),
+        Ref(public_subnet_b),
     ],
     SecurityGroups=[Ref(load_balancer_security_group)],
     Listeners=listeners,

--- a/stack/security_groups.py
+++ b/stack/security_groups.py
@@ -6,7 +6,7 @@ from troposphere.ec2 import SecurityGroup, SecurityGroupRule
 
 from .common import administrator_ip_address
 from .template import template
-from .vpc import loadbalancer_a_subnet_cidr, loadbalancer_b_subnet_cidr, vpc
+from .vpc import public_subnet_a_cidr, public_subnet_b_cidr, vpc
 
 load_balancer_security_group = SecurityGroup(
     "LoadBalancerSecurityGroup",
@@ -41,7 +41,7 @@ else:
     # web worker port (80)
     web_worker_ports = ["80"]
 
-cidrs = [Ref(loadbalancer_a_subnet_cidr), Ref(loadbalancer_b_subnet_cidr)]
+cidrs = [Ref(public_subnet_a_cidr), Ref(public_subnet_b_cidr)]
 
 # HTTP from web public subnets
 ingress_rules = [SecurityGroupRule(

--- a/stack/vpc.py
+++ b/stack/vpc.py
@@ -167,7 +167,7 @@ public_route = Route(
 )
 
 
-# Holds load balancer
+# Holds load balancer, NAT gateway, and bastion (if specified)
 public_subnet_a = Subnet(
     "PublicSubnetA",
     template=template,
@@ -175,7 +175,7 @@ public_subnet_a = Subnet(
     CidrBlock=Ref(public_subnet_a_cidr),
     AvailabilityZone=Ref(primary_az),
     Tags=Tags(
-        Name=Join("-", [Ref("AWS::StackName"), "elb-a"]),
+        Name=Join("-", [Ref("AWS::StackName"), "public-a"]),
     ),
 )
 
@@ -193,7 +193,7 @@ public_subnet_b = Subnet(
     CidrBlock=Ref(public_subnet_b_cidr),
     AvailabilityZone=Ref(secondary_az),
     Tags=Tags(
-        Name=Join("-", [Ref("AWS::StackName"), "elb-b"]),
+        Name=Join("-", [Ref("AWS::StackName"), "public-b"]),
     ),
 )
 
@@ -255,7 +255,7 @@ private_subnet_a = Subnet(
     MapPublicIpOnLaunch=not USE_NAT_GATEWAY,
     AvailabilityZone=Ref(primary_az),
     Tags=Tags(
-        Name=Join("-", [Ref("AWS::StackName"), "container-a"]),
+        Name=Join("-", [Ref("AWS::StackName"), "private-a"]),
     ),
 )
 
@@ -276,7 +276,7 @@ private_subnet_b = Subnet(
     MapPublicIpOnLaunch=not USE_NAT_GATEWAY,
     AvailabilityZone=Ref(secondary_az),
     Tags=Tags(
-        Name=Join("-", [Ref("AWS::StackName"), "container-b"]),
+        Name=Join("-", [Ref("AWS::StackName"), "private-b"]),
     ),
 )
 


### PR DESCRIPTION
The "container" and "load balancer" subnet nomenclature is a remnant of the code this was forked from... I'd like to move away from it in favor of simply having 2 public and 2 private subnets. Since I think we have some backwards-incompatible changes already on develop, this is probably as good a time as any to do it (i.e., before the next release).