### PR TITLE
Block all public access for the private assets bucket.

### DIFF
--- a/stack/assets.py
+++ b/stack/assets.py
@@ -131,7 +131,10 @@ private_assets_bucket = template.add_resource(
         "PrivateAssetsBucket",
         AccessControl=Private,
         PublicAccessBlockConfiguration=PublicAccessBlockConfiguration(
-            IgnorePublicAcls=True
+            BlockPublicAcls=True,
+            BlockPublicPolicy=True,
+            IgnorePublicAcls=True,
+            RestrictPublicBuckets=True,
         ),
         **common_bucket_conf,
     )


### PR DESCRIPTION
Checks all of the boxes here for the private bucket:

![block public access](https://docs.aws.amazon.com/AmazonS3/latest/user-guide/images/edit-public-access-multiple.png)