### PR TITLE
Add db + cache endpoint outputs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,7 @@ What's new in 2.0.0:
 * Add a parameter to specify the default canned ACL for the public assets bucket.
 * Block all public access for the private assets bucket.
 * Add parameters to customize VPC and subnet IPv4 CIDR blocks (**It is generally not possible to change the CIDR blocks for an existing stack.**).
+* Add RDS and ElastiCache endpoint outputs.
 
 
 `1.4.0`_ (2019-08-05)


### PR DESCRIPTION
Add RDS + Elasticache endpoint outputs to the CF stack. This is useful when you want to dynamically pull resources endpoints from CF without having to dig deep into each resource. This PR adds individual outputs as well as URL-variant combined outputs (thanks @cchurch) that can be used for different scenarios.

Example key/values:

- ``CacheAddress``: ``aaa.0001.use1.cache.amazonaws.com``
- ``CachePort``: ``6379``
- ``CacheURL``:  ``redis://aaa.use1.cache.amazonaws.com:6379``
- ``DatabaseAddress``: ``aaa.us-east-1.rds.amazonaws.com``
- ``DatabasePort``: ``3306``
- ``DatabaseURL``: ``mysql://user:_PASSWORD_@aaa.us-east-1.rds.amazonaws.com:3306/name``