### PR TITLE
allow specifying log types to log to CloudWatch Logs via stack parameter

### DIFF
--- a/stack/database.py
+++ b/stack/database.py
@@ -278,6 +278,18 @@ db_backup_retention_days = template.add_parameter(
     label="Backup Retention Days",
 )
 
+db_logging = template.add_parameter(
+    Parameter(
+        "DatabaseCloudWatchLogTypes",
+        Default="",
+        Description="A comma-separated list of the RDS log types (if any) to publish to "
+                    "CloudWatch Logs. Note that log types are database engine-specific.",
+        Type="CommaDelimitedList",
+    ),
+    group="Database",
+    label="Database Log Types",
+)
+
 db_security_group = ec2.SecurityGroup(
     'DatabaseSecurityGroup',
     template=template,
@@ -330,6 +342,7 @@ db_instance = rds.DBInstance(
     VPCSecurityGroups=[Ref(db_security_group)],
     DBParameterGroupName=Ref(db_parameter_group),
     BackupRetentionPeriod=Ref(db_backup_retention_days),
+    EnableCloudwatchLogsExports=Ref(db_logging),
     DeletionPolicy="Snapshot",
 )
 

--- a/stack/database.py
+++ b/stack/database.py
@@ -282,6 +282,12 @@ db_logging = template.add_parameter(
     Parameter(
         "DatabaseCloudWatchLogTypes",
         Default="",
+        # For RDS on Postgres, an appropriate setting for this might be "postgresql,upgrade".
+        # This parameter corresponds to the "EnableCloudwatchLogsExports" option on the DBInstance.
+        # This option is not particularly well documented by AWS, but it looks like if you
+        # go to the "Modify" screen via the RDS console you can see the types supported by your
+        # instance. Then, lowercase it and remove " log" from the type, i.e., "Postgresql log"
+        # will be come "postgresql" for this parameter.
         Description="A comma-separated list of the RDS log types (if any) to publish to "
                     "CloudWatch Logs. Note that log types are database engine-specific.",
         Type="CommaDelimitedList",


### PR DESCRIPTION
For RDS on Postgres, an appropriate setting for this might be "postgresql,upgrade"

It's not particularly well documented by RDS, but it looks like if you go to the "Modify" screen via the console you can see the types supported by your instance. Then, lowercase it and remove " log" from the type so it looks like the above.

