### PR TITLE
Encrypt Elasticache

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,7 @@ Change Log
 
 What's new in 2.0.0:
 
-* Re-purpose use_aes256_encryption flag to support encryption across S3, RDS, and RDS (thanks @dsummersl)
+* Re-purpose use_aes256_encryption flag to support encryption across S3, RDS, Elasticache (Redis only), and RDS (thanks @dsummersl)
 * Add configurable ContainerVolumeSize to change root volume size of EC2 instances (thanks @dsummersl)
 * Change generated template output from JSON to YAML (thanks @cchurch)
 * Add required DBParameterGroup by default, which allows configuring database specific parameters. This avoids having to reboot a production database instance to add a DBParameterGroup in the future. (thanks @cchurch)

--- a/stack/cache.py
+++ b/stack/cache.py
@@ -13,7 +13,11 @@ from troposphere import (
     elasticache
 )
 
-from .common import dont_create_value, use_aes256_encryption, use_aes256_encryption_cond
+from .common import (
+    dont_create_value,
+    use_aes256_encryption,
+    use_aes256_encryption_cond,
+)
 from .template import template
 from .utils import ParameterWithDefaults as Parameter
 from .vpc import (

--- a/stack/cache.py
+++ b/stack/cache.py
@@ -16,7 +16,7 @@ from troposphere import (
 from .common import (
     dont_create_value,
     use_aes256_encryption,
-    use_aes256_encryption_cond,
+    use_aes256_encryption_cond
 )
 from .template import template
 from .utils import ParameterWithDefaults as Parameter

--- a/stack/cache.py
+++ b/stack/cache.py
@@ -148,6 +148,7 @@ cache_subnet_group = elasticache.SubnetGroup(
 
 cache_cluster = elasticache.CacheCluster(
     "CacheCluster",
+    ClusterName=Join("-", [Ref("AWS::StackName"), "cache"]),
     template=template,
     Engine=Ref(cache_engine),
     CacheNodeType=Ref(cache_node_type),
@@ -173,6 +174,7 @@ replication_group = elasticache.ReplicationGroup(
     Condition=using_redis_condition,
     NumNodeGroups=1,
     Port=6379,
+    ReplicationGroupId=Join("-", [Ref("AWS::StackName"), "cache"]),
     ReplicationGroupDescription="Redis ReplicationGroup",
     SecurityGroupIds=[Ref(cache_security_group)],
     TransitEncryptionEnabled=use_aes256_encryption,

--- a/stack/cache.py
+++ b/stack/cache.py
@@ -152,9 +152,9 @@ cache_cluster = elasticache.CacheCluster(
     template=template,
     Engine=Ref(cache_engine),
     CacheNodeType=Ref(cache_node_type),
-    Condition=cache_condition,
+    Condition=using_memcached_condition,
     NumCacheNodes=1,  # Must be 1 for redis, but still required
-    Port=If(using_redis_condition, 6379, 11211),
+    Port=11211,
     VpcSecurityGroupIds=[Ref(cache_security_group)],
     CacheSubnetGroupName=Ref(cache_subnet_group),
     Tags=Tags(
@@ -162,7 +162,7 @@ cache_cluster = elasticache.CacheCluster(
     ),
 )
 
-replication_group = elasticache.ReplicationGroup(
+redis_replication_group = elasticache.ReplicationGroup(
     "CacheReplicationGroup",
     template=template,
     AtRestEncryptionEnabled=use_aes256_encryption,
@@ -191,7 +191,7 @@ cache_address = If(
     cache_condition,
     If(
         using_redis_condition,
-        GetAtt(replication_group, 'PrimaryEndPoint.Address'),
+        GetAtt(redis_replication_group, 'PrimaryEndPoint.Address'),
         GetAtt(cache_cluster, 'ConfigurationEndpoint.Address')
     ),
     "",  # defaults to empty string if no cache was created
@@ -201,7 +201,7 @@ cache_port = If(
     cache_condition,
     If(
         using_redis_condition,
-        GetAtt(replication_group, 'PrimaryEndPoint.Port'),
+        GetAtt(redis_replication_group, 'PrimaryEndPoint.Port'),
         GetAtt(cache_cluster, 'ConfigurationEndpoint.Port')
     ),
     "",  # defaults to empty string if no cache was created

--- a/stack/environment.py
+++ b/stack/environment.py
@@ -10,12 +10,6 @@ from .assets import (
     distribution,
     private_assets_bucket
 )
-from .cache import (
-    cache_cluster,
-    cache_condition,
-    cache_engine,
-    using_redis_condition
-)
 from .common import secret_key
 from .database import (
     db_condition,
@@ -58,25 +52,7 @@ environment_variables = [
         ]),
         "",  # defaults to empty string if no DB was created
     )),
-    ("CACHE_URL", If(
-        cache_condition,
-        Join("", [
-            Ref(cache_engine),
-            "://",
-            If(
-                using_redis_condition,
-                GetAtt(cache_cluster, 'RedisEndpoint.Address'),
-                GetAtt(cache_cluster, 'ConfigurationEndpoint.Address')
-            ),
-            ":",
-            If(
-                using_redis_condition,
-                GetAtt(cache_cluster, 'RedisEndpoint.Port'),
-                GetAtt(cache_cluster, 'ConfigurationEndpoint.Port')
-            ),
-        ]),
-        "",  # defaults to empty string if no cache was created
-    )),
+    ("CACHE_URL", Ref("CacheURL")),
 ]
 
 if distribution:


### PR DESCRIPTION
* Support Elasticache encryption (Redis-only)
  * Switches Redis to ``ReplicationGroup``, rather than ``CacheCluster``
* Name Cache resources to identify them more easily in the console