### PR TITLE
Support both Redis (with encryption) and Memcached

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Change Log
 
 * Update RDS resource name of database to be ``DatabaseInstance`` rather than ``PostgreSQL``. While other engines were previously supported, the title within the stack still referenced PostgreSQL. **This change will force a recreation of your RDS instance.**
 * Simplify the VPC layout to have 2 public and 2 private subnets. Due to this change, **updating an existing stack is not supported.**  You'll need to create a new stack and re-deploy all services within it.
+* Add support for running configuring Memcached and Redis clusters in tandem. The resource names have been adjusted to make this change and will force creation of new instances.
 
 What's new in 2.0.0:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,7 +15,7 @@ Change Log
 
 * Update RDS resource name of database to be ``DatabaseInstance`` rather than ``PostgreSQL``. While other engines were previously supported, the title within the stack still referenced PostgreSQL. **This change will force a recreation of your RDS instance.**
 * Simplify the VPC layout to have 2 public and 2 private subnets. Due to this change, **updating an existing stack is not supported.**  You'll need to create a new stack and re-deploy all services within it.
-* Add support for running configuring Memcached and Redis clusters in tandem. The resource names have been adjusted to make this change and will force creation of new instances.
+* Add support to provision Memcached and Redis clusters in tandem. The resource names have been adjusted to make this change and will force creation of new instances, possibly requiring a new stack.
 
 What's new in 2.0.0:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,7 @@ Change Log
 
 What's new in 2.0.0:
 
-* Re-purpose use_aes256_encryption flag to support encryption across S3, RDS, and RDS (thanks @dsummersl)
+* Re-purpose use_aes256_encryption flag to support encryption across S3, RDS, Elasticache (Redis only), and RDS (thanks @dsummersl)
 * Add configurable ContainerVolumeSize to change root volume size of EC2 instances (thanks @dsummersl)
 * Change generated template output from JSON to YAML (thanks @cchurch)
 * Add required DBParameterGroup by default, which allows configuring database specific parameters. This avoids having to reboot a production database instance to add a DBParameterGroup in the future. (thanks @cchurch)

--- a/stack/cache.py
+++ b/stack/cache.py
@@ -109,6 +109,17 @@ using_auth_token_condition = "AuthTokenCondition"
 template.add_condition(using_auth_token_condition,
                        Not(Equals(Ref(redis_auth_token), auth_token_dont_create_value)))
 
+redis_version = template.add_parameter(
+    Parameter(
+        "RedisVersion",
+        Default="",
+        Description="Redis version to use. See available versions: aws elasticache describe-cache-engine-versions",
+        Type="String",
+    ),
+    group="Redis",
+    label="Redis Version",
+)
+
 redis_num_cache_clusters = Ref(template.add_parameter(
     Parameter(
         "RedisNumCacheClusters",
@@ -244,6 +255,7 @@ redis_replication_group = elasticache.ReplicationGroup(
     AutomaticFailoverEnabled=Ref(redis_automatic_failover),
     AuthToken=If(using_auth_token_condition, Ref(redis_auth_token), Ref("AWS::NoValue")),
     Engine="redis",
+    EngineVersion=Ref(redis_version),
     CacheNodeType=Ref(redis_node_type),
     CacheSubnetGroupName=Ref(cache_subnet_group),
     Condition=using_redis_condition,

--- a/stack/cache.py
+++ b/stack/cache.py
@@ -23,7 +23,13 @@ from .common import (
 from .security_groups import container_security_group
 from .template import template
 from .utils import ParameterWithDefaults as Parameter
-from .vpc import private_subnet_a, private_subnet_b, vpc, primary_az, secondary_az
+from .vpc import (
+    primary_az,
+    private_subnet_a,
+    private_subnet_b,
+    secondary_az,
+    vpc
+)
 
 NODE_TYPES = [
     dont_create_value,

--- a/stack/cache.py
+++ b/stack/cache.py
@@ -13,7 +13,11 @@ from troposphere import (
     elasticache
 )
 
-from .common import dont_create_value, use_aes256_encryption, use_aes256_encryption_cond
+from .common import (
+    dont_create_value,
+    use_aes256_encryption,
+    use_aes256_encryption_cond,
+)
 from .template import template
 from .utils import ParameterWithDefaults as Parameter
 from .vpc import (

--- a/stack/cache.py
+++ b/stack/cache.py
@@ -6,9 +6,11 @@ from troposphere import (
     If,
     Join,
     Not,
+    Or,
     Output,
     Ref,
     Tags,
+    constants,
     ec2,
     elasticache
 )
@@ -18,93 +20,77 @@ from .common import (
     use_aes256_encryption,
     use_aes256_encryption_cond
 )
+from .security_groups import container_security_group
 from .template import template
 from .utils import ParameterWithDefaults as Parameter
-from .vpc import (
-    private_subnet_a,
-    private_subnet_a_cidr,
-    private_subnet_b,
-    private_subnet_b_cidr,
-    vpc
-)
+from .vpc import private_subnet_a, private_subnet_b, vpc
+
+NODE_TYPES = [
+    dont_create_value,
+    'cache.t2.micro',
+    'cache.t2.small',
+    'cache.t2.medium',
+    'cache.m3.medium',
+    'cache.m3.large',
+    'cache.m3.xlarge',
+    'cache.m3.2xlarge',
+    'cache.m4.large',
+    'cache.m4.xlarge',
+    'cache.m4.2xlarge',
+    'cache.m4.4xlarge',
+    'cache.m4.10xlarge',
+    'cache.r4.large',
+    'cache.r4.xlarge',
+    'cache.r4.2xlarge',
+    'cache.r4.4xlarge',
+    'cache.r4.8xlarge',
+    'cache.r4.16xlarge',
+    'cache.r3.large',
+    'cache.r3.xlarge',
+    'cache.r3.2xlarge',
+    'cache.r3.4xlarge',
+    'cache.r3.8xlarge',
+]
 
 cache_node_type = template.add_parameter(
     Parameter(
         "CacheNodeType",
-        Default="cache.t2.micro",
+        Default=dont_create_value,
         Description="Cache instance type",
         Type="String",
-        AllowedValues=[
-            dont_create_value,
-            'cache.t2.micro',
-            'cache.t2.small',
-            'cache.t2.medium',
-            'cache.m3.medium',
-            'cache.m3.large',
-            'cache.m3.xlarge',
-            'cache.m3.2xlarge',
-            'cache.m4.large',
-            'cache.m4.xlarge',
-            'cache.m4.2xlarge',
-            'cache.m4.4xlarge',
-            'cache.m4.10xlarge',
-            'cache.r4.large',
-            'cache.r4.xlarge',
-            'cache.r4.2xlarge',
-            'cache.r4.4xlarge',
-            'cache.r4.8xlarge',
-            'cache.r4.16xlarge',
-            'cache.r3.large',
-            'cache.r3.xlarge',
-            'cache.r3.2xlarge',
-            'cache.r3.4xlarge',
-            'cache.r3.8xlarge',
-        ],
+        AllowedValues=NODE_TYPES,
         ConstraintDescription="must select a valid cache node type.",
     ),
-    group="Cache",
+    group="Memcached",
     label="Instance Type",
 )
 
-cache_engine = template.add_parameter(
-    Parameter(
-        "CacheEngine",
-        Default="redis",
-        Description="Cache engine (redis or memcached)",
-        Type="String",
-        AllowedValues=[
-            'redis',
-            'memcached',
-        ],
-        ConstraintDescription="must select a valid cache engine.",
-    ),
-    group="Cache",
-    label="Engine",
-)
+using_memcached_condition = "UsingMemcached"
+template.add_condition(using_memcached_condition, Not(Equals(Ref(cache_node_type), dont_create_value)))
 
-cache_condition = "CacheCondition"
-template.add_condition(cache_condition, Not(Equals(Ref(cache_node_type), dont_create_value)))
+redis_node_type = template.add_parameter(
+    Parameter(
+        "RedisNodeType",
+        Default=dont_create_value,
+        Description="Redis instance type",
+        Type="String",
+        AllowedValues=NODE_TYPES,
+        ConstraintDescription="must select a valid cache node type.",
+    ),
+    group="Redis",
+    label="Instance Type",
+)
 
 using_redis_condition = "UsingRedis"
-template.add_condition(
-    using_redis_condition,
-    Equals(Ref(cache_engine), "redis"),
-)
-
-using_memcached_condition = "UsingMemcached"
-template.add_condition(
-    using_memcached_condition,
-    Equals(Ref(cache_engine), "memcached"),
-)
-
+template.add_condition(using_redis_condition, Not(Equals(Ref(redis_node_type), dont_create_value)))
 
 # Parameter constraints (MinLength, AllowedPattern, etc.) don't allow a blank value,
 # so we use a special "blank" do-not-create value
 auth_token_dont_create_value = 'DO_NOT_CREATE_AUTH_TOKEN'
 
-cache_auth_token = template.add_parameter(
+redis_auth_token = template.add_parameter(
     Parameter(
-        "CacheAuthToken",
+        "RedisAuthToken",
         NoEcho=True,
         Default=auth_token_dont_create_value,
         Description="The password used to access a Redis ReplicationGroup (required for HIPAA).",
@@ -115,32 +101,56 @@ cache_auth_token = template.add_parameter(
         ConstraintDescription="must consist of 16-128 printable ASCII "
                               "characters except \"/\", \"\"\", or \"@\"."
     ),
-    group="Cache",
+    group="Redis",
     label="AuthToken",
 )
 
-cache_auth_token_condition = "CacheAuthTokenCondition"
-template.add_condition(cache_auth_token_condition, Not(Equals(Ref(cache_auth_token), auth_token_dont_create_value)))
+using_auth_token_condition = "AuthTokenCondition"
+template.add_condition(using_auth_token_condition,
+                       Not(Equals(Ref(redis_auth_token), auth_token_dont_create_value)))
+
+secure_redis_condition = "SecureRedisCondition"
+template.add_condition(secure_redis_condition,
+                       And(Condition(using_redis_condition), Condition(use_aes256_encryption_cond)))
+
+using_either_cache_condition = "EitherCacheCondition"
+template.add_condition(using_either_cache_condition,
+                       Or(Condition(using_memcached_condition), Condition(using_redis_condition)))
+
+cache_subnet_group = elasticache.SubnetGroup(
+    "CacheSubnetGroup",
+    template=template,
+    Description="Subnets available for the cache instance",
+    Condition=using_either_cache_condition,
+    SubnetIds=[Ref(private_subnet_a), Ref(private_subnet_b)],
+)
 
 cache_security_group = ec2.SecurityGroup(
     'CacheSecurityGroup',
     template=template,
     GroupDescription="Cache security group.",
-    Condition=cache_condition,
+    Condition=using_either_cache_condition,
     VpcId=Ref(vpc),
     SecurityGroupIngress=[
-        # Redis in from web clusters
-        ec2.SecurityGroupRule(
-            IpProtocol="tcp",
-            FromPort=If(using_redis_condition, "6379", "11211"),
-            ToPort=If(using_redis_condition, "6379", "11211"),
-            CidrIp=Ref(private_subnet_a_cidr),
+        If(
+            using_memcached_condition,
+            ec2.SecurityGroupRule(
+                IpProtocol="tcp",
+                FromPort=constants.MEMCACHED_PORT,
+                ToPort=constants.MEMCACHED_PORT,
+                SourceSecurityGroupId=Ref(container_security_group),
+            ),
+            Ref("AWS::NoValue"),
         ),
-        ec2.SecurityGroupRule(
-            IpProtocol="tcp",
-            FromPort=If(using_redis_condition, "6379", "11211"),
-            ToPort=If(using_redis_condition, "6379", "11211"),
-            CidrIp=Ref(private_subnet_b_cidr),
+        If(
+            using_redis_condition,
+            ec2.SecurityGroupRule(
+                IpProtocol="tcp",
+                FromPort=constants.REDIS_PORT,
+                ToPort=constants.REDIS_PORT,
+                SourceSecurityGroupId=Ref(container_security_group),
+            ),
+            Ref("AWS::NoValue"),
         ),
     ],
     Tags=Tags(
@@ -148,23 +158,36 @@ cache_security_group = ec2.SecurityGroup(
     ),
 )
 
-cache_subnet_group = elasticache.SubnetGroup(
-    "CacheSubnetGroup",
+redis_replication_group = elasticache.ReplicationGroup(
+    "RedisReplicationGroup",
     template=template,
-    Description="Subnets available for the cache instance",
-    Condition=cache_condition,
-    SubnetIds=[Ref(private_subnet_a), Ref(private_subnet_b)],
+    AtRestEncryptionEnabled=use_aes256_encryption,
+    AutomaticFailoverEnabled=False,
+    AuthToken=If(using_auth_token_condition, Ref(redis_auth_token), Ref("AWS::NoValue")),
+    Engine="redis",
+    CacheNodeType=Ref(redis_node_type),
+    CacheSubnetGroupName=Ref(cache_subnet_group),
+    Condition=using_redis_condition,
+    NumNodeGroups=1,
+    Port=constants.REDIS_PORT,
+    ReplicationGroupId=Join("-", [Ref("AWS::StackName"), "redis"]),
+    ReplicationGroupDescription="Redis ReplicationGroup",
+    SecurityGroupIds=[Ref(cache_security_group)],
+    TransitEncryptionEnabled=use_aes256_encryption,
+    Tags=Tags(
+        Name=Join("-", [Ref("AWS::StackName"), "redis"]),
+    ),
 )
 
 cache_cluster = elasticache.CacheCluster(
     "CacheCluster",
     ClusterName=Join("-", [Ref("AWS::StackName"), "cache"]),
     template=template,
-    Engine=Ref(cache_engine),
+    Engine="memcached",
     CacheNodeType=Ref(cache_node_type),
     Condition=using_memcached_condition,
-    NumCacheNodes=1,  # Must be 1 for redis, but still required
-    Port=11211,
+    NumCacheNodes=1,
+    Port=constants.MEMCACHED_PORT,
     VpcSecurityGroupIds=[Ref(cache_security_group)],
     CacheSubnetGroupName=Ref(cache_subnet_group),
     Tags=Tags(
@@ -172,88 +195,93 @@ cache_cluster = elasticache.CacheCluster(
     ),
 )
 
-redis_replication_group = elasticache.ReplicationGroup(
-    "CacheReplicationGroup",
-    template=template,
-    AtRestEncryptionEnabled=use_aes256_encryption,
-    AutomaticFailoverEnabled=False,
-    AuthToken=If(cache_auth_token_condition, Ref(cache_auth_token), Ref("AWS::NoValue")),
-    Engine=Ref(cache_engine),
-    CacheNodeType=Ref(cache_node_type),
-    CacheSubnetGroupName=Ref(cache_subnet_group),
-    Condition=using_redis_condition,
-    NumNodeGroups=1,
-    Port=6379,
-    ReplicationGroupId=Join("-", [Ref("AWS::StackName"), "cache"]),
-    ReplicationGroupDescription="Redis ReplicationGroup",
-    SecurityGroupIds=[Ref(cache_security_group)],
-    TransitEncryptionEnabled=use_aes256_encryption,
-    Tags=Tags(
-        Name=Join("-", [Ref("AWS::StackName"), "cache"]),
-    ),
-)
-
-secure_redis_condition = "SecureRedisCondition"
-template.add_condition(secure_redis_condition,
-                       And(Condition(using_redis_condition), Condition(use_aes256_encryption_cond)))
-
 cache_address = If(
-    cache_condition,
-    If(
-        using_redis_condition,
-        GetAtt(redis_replication_group, 'PrimaryEndPoint.Address'),
-        GetAtt(cache_cluster, 'ConfigurationEndpoint.Address')
-    ),
-    "",  # defaults to empty string if no cache was created
+    using_memcached_condition,
+    GetAtt(cache_cluster, 'ConfigurationEndpoint.Address'),
+    "",
 )
 
 cache_port = If(
-    cache_condition,
-    If(
-        using_redis_condition,
-        GetAtt(redis_replication_group, 'PrimaryEndPoint.Port'),
-        GetAtt(cache_cluster, 'ConfigurationEndpoint.Port')
-    ),
-    "",  # defaults to empty string if no cache was created
+    using_memcached_condition,
+    GetAtt(cache_cluster, 'ConfigurationEndpoint.Port'),
+    "",
 )
 
 cache_url = If(
-    cache_condition,
+    using_memcached_condition,
     Join("", [
-        Ref(cache_engine),
-        If(secure_redis_condition, "s", ""),
-        "://",
-        If(cache_auth_token_condition, ":_PASSWORD_@", ""),
+        "memcached://",
         cache_address,
         ":",
-        cache_port
+        cache_port,
     ]),
-    "",  # defaults to empty string if no cache was created
+    "",
 )
-
-template.add_output([
-    Output(
-        "CacheURL",
-        Description="URL to connect to the cache node/cluster.",
-        Value=cache_url,
-        Condition=cache_condition,
-    ),
-])
 
 template.add_output([
     Output(
         "CacheAddress",
         Description="The DNS address for the cache node/cluster.",
         Value=cache_address,
-        Condition=cache_condition,
+        Condition=using_memcached_condition,
     ),
-])
-
-template.add_output([
     Output(
         "CachePort",
         Description="The port number for the cache node/cluster.",
-        Value=cache_port,
-        Condition=cache_condition,
+        Value=GetAtt(cache_cluster, 'ConfigurationEndpoint.Port'),
+        Condition=using_memcached_condition,
+    ),
+    Output(
+        "CacheURL",
+        Description="URL to connect to the cache node/cluster.",
+        Value=cache_url,
+        Condition=using_memcached_condition,
+    ),
+])
+
+redis_address = If(
+    using_redis_condition,
+    GetAtt(redis_replication_group, 'PrimaryEndPoint.Address'),
+    "",
+)
+
+redis_port = If(
+    using_redis_condition,
+    GetAtt(redis_replication_group, 'PrimaryEndPoint.Port'),
+    "",
+)
+
+redis_url = If(
+    using_redis_condition,
+    Join("", [
+        "redis",
+        If(secure_redis_condition, "s", ""),
+        "://",
+        If(using_auth_token_condition, ":_PASSWORD_@", ""),
+        redis_address,
+        ":",
+        redis_port,
+    ]),
+    "",
+)
+
+template.add_output([
+    Output(
+        "RedisAddress",
+        Description="The DNS address for the Redis node/cluster.",
+        Value=redis_address,
+        Condition=using_redis_condition,
+    ),
+    Output(
+        "RedisPort",
+        Description="The port number for the Redis node/cluster.",
+        Value=redis_port,
+        Condition=using_redis_condition,
+    ),
+    Output(
+        "RedisURL",
+        Description="URL to connect to the Redis node/cluster.",
+        Value=redis_url,
+        Condition=using_redis_condition,
     ),
 ])

--- a/stack/cache.py
+++ b/stack/cache.py
@@ -16,7 +16,7 @@ from troposphere import (
 from .common import (
     dont_create_value,
     use_aes256_encryption,
-    use_aes256_encryption_cond,
+    use_aes256_encryption_cond
 )
 from .template import template
 from .utils import ParameterWithDefaults as Parameter

--- a/stack/cache.py
+++ b/stack/cache.py
@@ -148,6 +148,7 @@ cache_subnet_group = elasticache.SubnetGroup(
 
 cache_cluster = elasticache.CacheCluster(
     "CacheCluster",
+    ClusterName=Join("-", [Ref("AWS::StackName"), "cache"]),
     template=template,
     Engine=Ref(cache_engine),
     CacheNodeType=Ref(cache_node_type),
@@ -173,6 +174,7 @@ replication_group = elasticache.ReplicationGroup(
     Condition=using_redis_condition,
     NumNodeGroups=1,
     Port=6379,
+    ReplicationGroupId=Join("-", [Ref("AWS::StackName"), "cache"]),
     ReplicationGroupDescription="Redis ReplicationGroup",
     SecurityGroupIds=[Ref(cache_security_group)],
     TransitEncryptionEnabled=use_aes256_encryption,

--- a/stack/cache.py
+++ b/stack/cache.py
@@ -131,30 +131,6 @@ redis_num_cache_clusters = Ref(template.add_parameter(
     label="Number of node groups",
 ))
 
-redis_num_node_groups = Ref(template.add_parameter(
-    Parameter(
-        "RedisNumNodeGroups",
-        Description=""
-        "Number of node groups for this Redis (cluster mode enabled) replication group. For "
-        "Redis (cluster mode disabled) either omit this parameter or set it to 1.",
-        Type="Number",
-        Default="1",
-    ),
-    group="Redis",
-    label="Number of node groups",
-))
-
-redis_replicas_per_group = Ref(template.add_parameter(
-    Parameter(
-        "RedisReplicasPerNodeGroup",
-        Description="Number of replica nodes",
-        Type="Number",
-        Default="0",
-    ),
-    group="Redis",
-    label="Number of replica nodes",
-))
-
 redis_snapshot_retention_limit = Ref(template.add_parameter(
     Parameter(
         "RedisSnapshotRetentionLimit",
@@ -260,12 +236,9 @@ redis_replication_group = elasticache.ReplicationGroup(
     CacheSubnetGroupName=Ref(cache_subnet_group),
     Condition=using_redis_condition,
     NumCacheClusters=redis_num_cache_clusters,
-    # NumNodeGroups=redis_num_node_groups,
     Port=constants.REDIS_PORT,
     PreferredCacheClusterAZs=[Ref(primary_az), Ref(secondary_az)],
-    # ReplicationGroupId=Join("-", [Ref("AWS::StackName"), "redis"]),  # custom named groups can't be updated when ..
     ReplicationGroupDescription="Redis ReplicationGroup",
-    # ReplicasPerNodeGroup=redis_replicas_per_group,
     SecurityGroupIds=[Ref(cache_security_group)],
     SnapshotRetentionLimit=redis_snapshot_retention_limit,
     TransitEncryptionEnabled=use_aes256_encryption,

--- a/stack/cache.py
+++ b/stack/cache.py
@@ -152,9 +152,9 @@ cache_cluster = elasticache.CacheCluster(
     template=template,
     Engine=Ref(cache_engine),
     CacheNodeType=Ref(cache_node_type),
-    Condition=cache_condition,
+    Condition=using_memcached_condition,
     NumCacheNodes=1,  # Must be 1 for redis, but still required
-    Port=If(using_redis_condition, 6379, 11211),
+    Port=11211,
     VpcSecurityGroupIds=[Ref(cache_security_group)],
     CacheSubnetGroupName=Ref(cache_subnet_group),
     Tags=Tags(
@@ -162,7 +162,7 @@ cache_cluster = elasticache.CacheCluster(
     ),
 )
 
-replication_group = elasticache.ReplicationGroup(
+redis_replication_group = elasticache.ReplicationGroup(
     "CacheReplicationGroup",
     template=template,
     AtRestEncryptionEnabled=use_aes256_encryption,
@@ -191,7 +191,7 @@ cache_address = If(
     cache_condition,
     If(
         using_redis_condition,
-        GetAtt(replication_group, 'PrimaryEndPoint.Address'),
+        GetAtt(redis_replication_group, 'PrimaryEndPoint.Address'),
         GetAtt(cache_cluster, 'ConfigurationEndpoint.Address')
     ),
     "",  # defaults to empty string if no cache was created
@@ -201,7 +201,7 @@ cache_port = If(
     cache_condition,
     If(
         using_redis_condition,
-        GetAtt(replication_group, 'PrimaryEndPoint.Port'),
+        GetAtt(redis_replication_group, 'PrimaryEndPoint.Port'),
         GetAtt(cache_cluster, 'ConfigurationEndpoint.Port')
     ),
     "",  # defaults to empty string if no cache was created

--- a/stack/cache.py
+++ b/stack/cache.py
@@ -173,6 +173,8 @@ using_either_cache_condition = "EitherCacheCondition"
 template.add_condition(using_either_cache_condition,
                        Or(Condition(using_memcached_condition), Condition(using_redis_condition)))
 
+# Subnet and security group shared by both clusters
+
 cache_subnet_group = elasticache.SubnetGroup(
     "CacheSubnetGroup",
     template=template,
@@ -216,7 +218,6 @@ cache_security_group = ec2.SecurityGroup(
 
 cache_cluster = elasticache.CacheCluster(
     "CacheCluster",
-    ClusterName=Join("-", [Ref("AWS::StackName"), "cache"]),
     template=template,
     Engine="memcached",
     CacheNodeType=Ref(cache_node_type),

--- a/stack/environment.py
+++ b/stack/environment.py
@@ -10,12 +10,6 @@ from .assets import (
     distribution,
     private_assets_bucket
 )
-from .cache import (
-    cache_cluster,
-    cache_condition,
-    cache_engine,
-    using_redis_condition
-)
 from .common import secret_key
 from .database import (
     db_condition,
@@ -58,25 +52,7 @@ environment_variables = [
         ]),
         "",  # defaults to empty string if no DB was created
     )),
-    ("CACHE_URL", If(
-        cache_condition,
-        Join("", [
-            Ref(cache_engine),
-            "://",
-            If(
-                using_redis_condition,
-                GetAtt(cache_cluster, 'RedisEndpoint.Address'),
-                GetAtt(cache_cluster, 'ConfigurationEndpoint.Address')
-            ),
-            ":",
-            If(
-                using_redis_condition,
-                GetAtt(cache_cluster, 'RedisEndpoint.Port'),
-                GetAtt(cache_cluster, 'ConfigurationEndpoint.Port')
-            ),
-        ]),
-        "",  # defaults to empty string if no cache was created
-    )),
+    ("CACHE_URL", Ref("CacheURL")),
 ]
 
 if distribution:

--- a/stack/environment.py
+++ b/stack/environment.py
@@ -10,6 +10,7 @@ from .assets import (
     distribution,
     private_assets_bucket
 )
+from .cache import cache_url, redis_url
 from .common import secret_key
 from .database import (
     db_condition,
@@ -52,7 +53,8 @@ environment_variables = [
         ]),
         "",  # defaults to empty string if no DB was created
     )),
-    ("CACHE_URL", Ref("CacheURL")),
+    ("CACHE_URL", cache_url),
+    ("REDIS_URL", redis_url),
 ]
 
 if distribution:


### PR DESCRIPTION
Allow stacks to provision both Redis and Memcached clusters.

Memcached (``CacheCluster``) now only controlled by ``CacheNodeType``.

Redis now uses ``elasticache.ReplicationGroup`` rather than ``elasticache.CacheCluster`` to support (optionally) at-rest and in-transit encryption. The combination of ``UseAES256Encryption`` and ``RedisAuthToken`` brings the stack closer to [HIPAA compliance](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/elasticache-compliance.html#elasticache-compliance-hipaa).

Redis is customized with:
* ``RedisNodeType``
* ``RedisAuthToken``: password authentication for Redis
* ``RedisVersion``: to optionally support [older versions](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/SelectEngine.html)
* ``RedisNumCacheClusters``: number of clusters in the replication group, if >1 they will be distributed into the 2 VPC availability zones
* ``RedisSnapshotRetentionLimit``: days snapshots are retained before deletion
* ``RedisAutomaticFailover``: if ``true``, a read-only replica is automatically promoted to read/write primary if the existing primary fails

Redis and Memcached share the same subnet and security groups for simplicity.