### PR TITLE
Add optional database replica.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,7 @@ What's new in 2.0.0:
 * Add parameters to customize VPC and subnet IPv4 CIDR blocks (**It is generally not possible to change the CIDR blocks for an existing stack.**).
 * Add RDS and ElastiCache endpoint outputs.
 * Add CustomAppCertificateArn parameter to allow association with an existing ACM certificate.
+* Add DatabaseReplication parameter to add a database replica (** this will fail if DatabaseBackupRetentionDays is 0.**).
 
 
 `1.4.0`_ (2019-08-05)

--- a/README.rst
+++ b/README.rst
@@ -310,6 +310,8 @@ These environment variables are:
 * ``DATABASE_URL``: The URL to the RDS instance created as part of this stack. If ``(none)`` is
   selected for the ``DatabaseClass`` during stack creation, the value of this variable will be
   an empty string (``''``).
+* ``DATABASE_REPLICA_URL``: The URL to the RDS database replica instance. This is an empty string
+  if there's no replica database.
 * ``CACHE_URL``: The URL to the Redis or Memcached instance created as part of this stack (may be
   used as a cache or session storage, e.g.). If using Redis, note that it supports multiple
   databases and no database ID is included as part of the URL, so you should append a forward slash

--- a/stack/database.py
+++ b/stack/database.py
@@ -105,7 +105,8 @@ db_replication = template.add_parameter(
         Type="String",
         AllowedValues=["true", "false"],
         Default="false",
-        Description="Whether to create a database server replica - WARNING this will fail if DatabaseBackupRetentionDays is 0.",
+        Description="Whether to create a database server replica - "
+        "WARNING this will fail if DatabaseBackupRetentionDays is 0.",
     ),
     group="Database",
     label="Database replication"

--- a/stack/environment.py
+++ b/stack/environment.py
@@ -18,6 +18,8 @@ from .database import (
     db_instance,
     db_name,
     db_password,
+    db_replica,
+    db_replication_condition,
     db_user
 )
 from .domain import domain_name, domain_name_alternates
@@ -48,6 +50,23 @@ environment_variables = [
             GetAtt(db_instance, 'Endpoint.Address'),
             ":",
             GetAtt(db_instance, 'Endpoint.Port'),
+            "/",
+            Ref(db_name),
+        ]),
+        "",  # defaults to empty string if no DB was created
+    )),
+    ("DATABASE_REPLICA_URL", If(
+        db_replication_condition,
+        Join("", [
+            Ref(db_engine),
+            "://",
+            Ref(db_user),
+            ":",
+            Ref(db_password),
+            "@",
+            GetAtt(db_replica, 'Endpoint.Address'),
+            ":",
+            GetAtt(db_replica, 'Endpoint.Port'),
             "/",
             Ref(db_name),
         ]),


### PR DESCRIPTION
New parameter DatabaseReplication, set to "true"
to add a replica. Also be sure in this case that
DatabaseBackupRetentionDays is at least 1 (AWS CF
requirement in order to create a replica).

The outputs will include DatabaseReplicaURL and
DatabaseReplicaAddress, and where applicable, execution
environments will include DATABASE_REPLICA_URL.