### PR TITLE
Don't apply CMK encryption to public buckets

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,7 +20,7 @@ Change Log
 What's new in 2.0.0:
 
 * Re-purpose use_aes256_encryption flag to support encryption across S3, RDS, Elasticache (Redis only), and RDS (thanks @dsummersl)
-* Add support for Customer Managed CMKs with ``CustomerManagedCmkArn`` parameter
+* Add support for Customer Managed CMKs with ``CustomerManagedCmkArn`` parameter (not applied to public buckets)
 * Add configurable ContainerVolumeSize to change root volume size of EC2 instances (thanks @dsummersl)
 * Change generated template output from JSON to YAML (thanks @cchurch)
 * Add required DBParameterGroup by default, which allows configuring database specific parameters. This avoids having to reboot a production database instance to add a DBParameterGroup in the future. (thanks @cchurch)

--- a/stack/common.py
+++ b/stack/common.py
@@ -158,7 +158,7 @@ template.add_condition(use_aes256_encryption_cond, Equals(use_aes256_encryption,
 cmk_arn = template.add_parameter(
     Parameter(
         "CustomerManagedCmkArn",
-        Description="KMS CMK ARN to encrypt stack resources.",
+        Description="KMS CMK ARN to encrypt stack resources (except for public buckets).",
         Type="String",
         Default="",
     ),


### PR DESCRIPTION
If a bucket is encrypted with customer-managed-key encryption,
its files cannot be served publicly because they can only be
accessed using properly authorized API calls.

This change notices if encryption is enabled generally and customer
managed keys are also enabled, and just for the public assets
bucket, sets its encryption to AES256 instead.