### PR TITLE
Update to Troposphere 2.6.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 awacs==0.9.6
-troposphere==2.5.2
+troposphere==2.6.0
 flake8==3.4.1
 isort==4.2.15
 sphinx==1.6.7


### PR DESCRIPTION
The output is unchanged, apart from the datestamps in the
comments, but this will let us stop having to subclass
Nodegroup to fix it in our eks branch.