### PR TITLE
remove extraneous Ref() when using a NAT gateway

### DIFF
--- a/stack/vpc.py
+++ b/stack/vpc.py
@@ -255,7 +255,7 @@ if USE_NAT_GATEWAY:
         template=template,
         ServiceName=Sub("com.amazonaws.${AWS::Region}.s3"),
         VpcId=Ref(vpc),
-        RouteTableIds=[Ref(private_route_table)],
+        RouteTableIds=[private_route_table],
     )
 else:
     private_route_table = Ref(public_route_table)


### PR DESCRIPTION
Getting the error "Template error: every Ref object must have a single String value." when attempting to use the NAT Gateway stack on AWS. Traced it to a double call to `Ref()` around `private_route_table` in one case.

This is currently targeting master, but if the other commits on develop are ready for release we could change the target.