### PR TITLE
fix a broken ref and dependency

### DIFF
--- a/stack/assets.py
+++ b/stack/assets.py
@@ -172,7 +172,9 @@ template.add_output(
 # Bucket for SFTP service
 sftp_assets_bucket = Bucket(
     "SFTPAssetsBucket",
-    Condition=use_sftp_condition,
+    # This bucket intentionally has no Condition (i.e., it is always created,
+    # even if SFTP is disabled) because it is referenced throughout the policies
+    # and roles in this file.
     AccessControl=Private,
     PublicAccessBlockConfiguration=PublicAccessBlockConfiguration(
         BlockPublicAcls=True,

--- a/stack/vpc.py
+++ b/stack/vpc.py
@@ -255,7 +255,7 @@ if USE_NAT_GATEWAY:
         template=template,
         ServiceName=Sub("com.amazonaws.${AWS::Region}.s3"),
         VpcId=Ref(vpc),
-        RouteTableIds=[Ref(private_route_table)],
+        RouteTableIds=[private_route_table],
     )
 else:
     private_route_table = Ref(public_route_table)


### PR DESCRIPTION
* There's a duplicate `Ref()` around `private_route_table` in one case
* The `SFTPAssetsBucket` seems to be required because it's referenced in a number of roles/policies (there's probably a way to do this that doesn't involve creating an unnecessary S3 bucket, but it's probably much more complex)
