### PR TITLE
WIP for v3: IPv6 support and VPC refactor

### DIFF
--- a/stack/database.py
+++ b/stack/database.py
@@ -24,13 +24,7 @@ from .common import (
 )
 from .template import template
 from .utils import ParameterWithDefaults as Parameter
-from .vpc import (
-    private_subnet_a,
-    private_subnet_a_cidr,
-    private_subnet_b,
-    private_subnet_b_cidr,
-    vpc
-)
+from .vpc import private_subnet_a, private_subnet_b, private_subnet_a_cidr, private_subnet_b_cidr, vpc
 
 rds_engine_map = OrderedDict([
     ("aurora", {"Port": "3306"}),
@@ -362,13 +356,13 @@ db_security_group = ec2.SecurityGroup(
             IpProtocol="tcp",
             FromPort=FindInMap("RdsEngineMap", Ref(db_engine), "Port"),
             ToPort=FindInMap("RdsEngineMap", Ref(db_engine), "Port"),
-            CidrIp=Ref(private_subnet_a_cidr),
+            CidrIp=private_subnet_a_cidr,
         ),
         ec2.SecurityGroupRule(
             IpProtocol="tcp",
             FromPort=FindInMap("RdsEngineMap", Ref(db_engine), "Port"),
             ToPort=FindInMap("RdsEngineMap", Ref(db_engine), "Port"),
-            CidrIp=Ref(private_subnet_b_cidr),
+            CidrIp=private_subnet_b_cidr,
         ),
     ],
     Tags=Tags(


### PR DESCRIPTION
This is still a work in progress (and shouldn't be merged until v3 anyways due to how it will require recreating all subnets in existing stacks), but it would be nice to refactor how the subnets are created at some point and add IPv6 support as well.

It's possible the IPv6 support could be pulled out and implemented separately if anyone needs it.

Filing this as a placeholder for now and in case any of these snippets are useful to anyone else.