### PR TITLE
Add logging permissions needed by aws-for-fluent-bit

### DIFF
--- a/stack/logs.py
+++ b/stack/logs.py
@@ -19,6 +19,9 @@ logging_policy = iam.Policy(
             Action=[
                 "logs:Create*",
                 "logs:PutLogEvents",
+                # Needed by aws-for-fluent-bit:
+                "logs:DescribeLogGroups",
+                "logs:DescribeLogStreams",
             ],
             Resource=Join("", [
                 arn_prefix,


### PR DESCRIPTION
Avoid lots of these:
```
AccessDeniedException: User: <snip> is not authorized to perform: logs:DescribeLogStreams on resource: <snip>
```