### PR TITLE
Upgrade to troposphere 4.2.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Change Log
 * Add support for `EKS EncryptionConfig <https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-encryptionconfig>`_. Set with ``EnableEksEncryptionConfig=true``.
 * Add ``EksClusterName`` parameter to control name of EKS cluster. If upgrading, set this to STACK_NAME-cluster to match existing name.
 * Drop support for RDS PostgreSQL 9.x
+* Upgrade to troposphere v4.2.0
 
 
 `2.1.2`_ (2022-03-10)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-awacs==2.1.0
-troposphere==2.6.3
+troposphere[policy]==3.2.2
 sphinx==1.6.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-troposphere[policy]==3.2.2
+troposphere[policy]==4.2.0
 sphinx==1.6.7

--- a/stack/eb.py
+++ b/stack/eb.py
@@ -5,7 +5,7 @@ from troposphere import FindInMap, GetAtt, Join, Output, Ref, iam
 from troposphere.elasticbeanstalk import (
     Application,
     Environment,
-    OptionSettings
+    OptionSetting
 )
 from troposphere.iam import InstanceProfile, Role
 
@@ -216,18 +216,18 @@ template.add_resource(Environment(
 
     OptionSettings=[
         # VPC settings
-        OptionSettings(
+        OptionSetting(
             Namespace="aws:ec2:vpc",
             OptionName="VPCId",
             Value=Ref(vpc),
         ),
-        OptionSettings(
+        OptionSetting(
             Namespace="aws:ec2:vpc",
             OptionName="AssociatePublicIpAddress",
             # instances need a public IP if we're not using a NAT gateway
             Value=str(not USE_NAT_GATEWAY).lower(),
         ),
-        OptionSettings(
+        OptionSetting(
             Namespace="aws:ec2:vpc",
             OptionName="Subnets",
             Value=Join(",", [
@@ -235,7 +235,7 @@ template.add_resource(Environment(
                 Ref(private_subnet_b),
             ]),
         ),
-        OptionSettings(
+        OptionSetting(
             Namespace="aws:ec2:vpc",
             OptionName="ELBSubnets",
             Value=Join(",", [
@@ -244,22 +244,22 @@ template.add_resource(Environment(
             ]),
         ),
         # Launch config settings
-        OptionSettings(
+        OptionSetting(
             Namespace="aws:autoscaling:launchconfiguration",
             OptionName="InstanceType",
             Value=container_instance_type,
         ),
-        OptionSettings(
+        OptionSetting(
             Namespace="aws:autoscaling:launchconfiguration",
             OptionName="EC2KeyName",
             Value=Ref(key_name),
         ),
-        OptionSettings(
+        OptionSetting(
             Namespace="aws:autoscaling:launchconfiguration",
             OptionName="IamInstanceProfile",
             Value=Ref(web_server_instance_profile),
         ),
-        OptionSettings(
+        OptionSetting(
             Namespace="aws:autoscaling:launchconfiguration",
             OptionName="SecurityGroups",
             Value=Join(",", [
@@ -267,7 +267,7 @@ template.add_resource(Environment(
             ]),
         ),
         # Load balancer settings
-        OptionSettings(
+        OptionSetting(
             Namespace="aws:elb:loadbalancer",
             OptionName="SecurityGroups",
             Value=Join(",", [
@@ -276,84 +276,84 @@ template.add_resource(Environment(
         ),
         # HTTPS Listener (note, these will not appear in the console -- only
         # the deprecated options which we are not using will appear there).
-        OptionSettings(
+        OptionSetting(
             Namespace="aws:elb:listener:443",
             OptionName="ListenerProtocol",
             Value="HTTPS",
         ),
-        OptionSettings(
+        OptionSetting(
             Namespace="aws:elb:listener:443",
             OptionName="SSLCertificateId",
             Value=application_certificate,
         ),
-        OptionSettings(
+        OptionSetting(
             Namespace="aws:elb:listener:443",
             OptionName="InstanceProtocol",
             Value="HTTP",
         ),
-        OptionSettings(
+        OptionSetting(
             Namespace="aws:elb:listener:443",
             OptionName="InstancePort",
             Value="80",
         ),
         # OS management options
-        # OptionSettings(
+        # OptionSetting(
         #     Namespace="aws:elasticbeanstalk:environment",
         # # allows AWS to reboot our instances with security updates
         #     OptionName="ServiceRole",
         # # should be created by EB by default
         #     Value="${aws_iam_role.eb_service_role.name),",
         # ),
-        # OptionSettings(
+        # OptionSetting(
         #     Namespace="aws:elasticbeanstalk:healthreporting:system",
         #     OptionName="SystemType", # required for managed updates
         #     Value="enhanced",
         # ),
-        # OptionSettings(
+        # OptionSetting(
         #     Namespace="aws:elasticbeanstalk:managedactions",
         # # required for managed updates
         #     OptionName="ManagedActionsEnabled",
         #     Value="true",
         # ),
-        # OptionSettings(
+        # OptionSetting(
         #     Namespace="aws:elasticbeanstalk:managedactions",
         #     OptionName="PreferredStartTime",
         #     Value="Sun:02:00",
         # ),
-        # OptionSettings(
+        # OptionSetting(
         #     Namespace="aws:elasticbeanstalk:managedactions:platformupdate",
         #     OptionName="UpdateLevel",
         #     Value="minor", # or "patch", ("minor", provides more updates)
         # ),
-        # OptionSettings(
+        # OptionSetting(
         #     Namespace="aws:elasticbeanstalk:managedactions:platformupdate",
         #     OptionName="InstanceRefreshEnabled",
         #     Value="true", # refresh instances weekly
         # ),
         # Logging configuration
-        OptionSettings(
+        OptionSetting(
             Namespace="aws:elasticbeanstalk:cloudwatch:logs",
             OptionName="StreamLogs",
             Value="true",
         ),
-        OptionSettings(
+        OptionSetting(
             Namespace="aws:elasticbeanstalk:cloudwatch:logs",
             OptionName="DeleteOnTerminate",
             Value="false",
         ),
-        OptionSettings(
+        OptionSetting(
             Namespace="aws:elasticbeanstalk:cloudwatch:logs",
             OptionName="RetentionInDays",
             Value="365",
         ),
         # Environment variables
-        OptionSettings(
+        OptionSetting(
             Namespace="aws:elb:listener:443",
             OptionName="InstancePort",
             Value="80",
         ),
     ] + [
-        OptionSettings(
+        OptionSetting(
             Namespace="aws:elasticbeanstalk:application:environment",
             OptionName=k,
             Value=v,

--- a/stack/repository.py
+++ b/stack/repository.py
@@ -1,7 +1,7 @@
 import awacs.ecr as ecr
 from awacs.aws import Allow, AWSPrincipal, Policy, Statement
 from troposphere import AWS_ACCOUNT_ID, AWS_REGION, Join, Output, Ref
-from troposphere.ecr import Repository
+from troposphere.ecr import ImageScanningConfiguration, Repository
 
 from .common import arn_prefix
 from .template import template
@@ -36,7 +36,7 @@ repository = Repository(
             ),
         ],
     ),
-    ImageScanningConfiguration={"ScanOnPush": "true"},
+    ImageScanningConfiguration=ImageScanningConfiguration(ScanOnPush=True),
 )
 
 

--- a/stack/tags.py
+++ b/stack/tags.py
@@ -13,6 +13,12 @@ def tags_types_of_resource(resource):
     tags_type = resource.props["Tags"][0]
     if isinstance(tags_type, tuple):
         return tags_type
+    if tags_type.__name__ == "validate_tags_or_list":
+        # In v3.2, auto-generated troposphere classes moved to class-specific
+        # validate_tags_or_list() functions rather than (Tags, list). Since it
+        # can be either option, we just default to Tags.
+        # Example: https://github.com/cloudtools/troposphere/commit/fdc9d0960a31cf2d903e4eeecf1012fe5ab16ced#diff-69b792424cfc3e822fcfb40d663731910b63d55cd0f6d5cd1166d55794be60b7L47-R62  # noqa
+        tags_type = Tags
     return [tags_type]
 
 


### PR DESCRIPTION
* Update to troposphere 4.2.0
* Python 3.10 compatible
* Fix pre-commit flake8 hook
* ([v3.0.0](https://github.com/cloudtools/troposphere/releases/tag/3.0.0)) Inherit spec improvements, like:
    * `SubnetGroup.Tags` support cloudtools/troposphere@24bfa2a9039359dbd9a095ef0cb9192024905391 
    * Booleans are output instead of string booleans for better interoperability
* ([v3.0.0](https://github.com/cloudtools/troposphere/releases/tag/3.0.0)) Rename ElasticBeanstalk OptionSettings
* ([v3.0.0](https://github.com/cloudtools/troposphere/releases/tag/3.0.0)) Use ECR ImageScanningConfiguration class
* ([v3.2.0](https://github.com/cloudtools/troposphere/releases/tag/3.2.0)) Fix tag detection with auto-generated troposphere classes. See cloudtools/troposphere@fdc9d0960a31cf2d903e4eeecf1012fe5ab16ced

Sample `eks-nat.yaml` YAML changes when compared to caktus/aws-web-stacks#115:

```diff
--- /code/deploy/stack/eks-nat-2.1.2.yml        2023-01-19 20:08:16.058037898 +0000
+++ content/eks-nat.yaml        2023-01-20 21:47:57.821404008 +0000
@@ -1,6 +1,6 @@
 # This Cloudformation stack template was generated by
 # https://github.com/caktus/aws-web-stacks
-# at 2022-03-24 11:41:09.141115
+# at 2023-01-20 21:47:57.744876
 # with parameters:
 #      USE_EKS = on
 #      USE_NAT_GATEWAY = on
@@ -1179,7 +1179,7 @@
   ApplicationRepository:
     Properties:
       ImageScanningConfiguration:
-        ScanOnPush: 'true'
+        ScanOnPush: true
       RepositoryPolicyText:
         Statement:
           - Action:
@@ -1271,10 +1271,10 @@
               - Origin
               - Access-Control-Request-Headers
               - Access-Control-Request-Method
-            QueryString: 'true'
+            QueryString: true
           TargetOriginId: Assets
           ViewerProtocolPolicy: allow-all
-        Enabled: 'true'
+        Enabled: true
         Origins:
           - DomainName: !GetAtt 'AssetsBucket.DomainName'
             Id: Assets
@@ -1450,6 +1450,9 @@
       SubnetIds:
         - !Ref 'PrivateSubnetA'
         - !Ref 'PrivateSubnetB'
+      Tags:
+        - Key: aws-web-stacks:stack-name
+          Value: !Ref 'AWS::StackName'
     Type: AWS::ElastiCache::SubnetGroup
   ContainerInstanceProfile:
     Properties:
@@ -1616,6 +1619,9 @@
     DeletionPolicy: Retain
     Properties:
       RetentionInDays: 365
+      Tags:
+        - Key: aws-web-stacks:stack-name
+          Value: !Ref 'AWS::StackName'
     Type: AWS::Logs::LogGroup
   ContainerSecurityGroupOpenVPNIngress:
     Condition: BastionTypeIsOpenVPNSet
@@ -1767,6 +1773,9 @@
           - !Ref 'PrivateSubnetA'
           - !Ref 'PrivateSubnetB'
       RoleArn: !GetAtt 'EksServiceRole.Arn'
+      Tags:
+        - Key: aws-web-stacks:stack-name
+          Value: !Ref 'AWS::StackName'
     Type: AWS::EKS::Cluster
   EksClusterSecurityGroup:
     Properties:
@@ -1811,7 +1820,7 @@
               AWS:
                 - !GetAtt 'ContainerInstanceRole.Arn'
       EBSOptions:
-        EBSEnabled: 'true'
+        EBSEnabled: true
         VolumeSize: !Ref 'ElasticsearchVolumeSize'
       ElasticsearchClusterConfig:
         InstanceType: !Ref 'ElasticsearchInstanceType'
@@ -1933,10 +1942,10 @@
                     - ;https://
                     - !Ref 'DomainNameAlternates'
       PublicAccessBlockConfiguration:
-        BlockPublicAcls: 'true'
-        BlockPublicPolicy: 'true'
-        IgnorePublicAcls: 'true'
-        RestrictPublicBuckets: 'true'
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
       Tags:
         - Key: aws-web-stacks:stack-name
           Value: !Ref 'AWS::StackName'
@@ -1947,7 +1956,7 @@
     Properties:
       AvailabilityZone: !Ref 'PrimaryAZ'
       CidrBlock: !Ref 'PrivateSubnetACidr'
-      MapPublicIpOnLaunch: 'false'
+      MapPublicIpOnLaunch: false
       Tags:
         - Key: aws-web-stacks:stack-name
           Value: !Ref 'AWS::StackName'
@@ -1969,7 +1978,7 @@
     Properties:
       AvailabilityZone: !Ref 'SecondaryAZ'
       CidrBlock: !Ref 'PrivateSubnetBCidr'
-      MapPublicIpOnLaunch: 'false'
+      MapPublicIpOnLaunch: false
       Tags:
         - Key: aws-web-stacks:stack-name
           Value: !Ref 'AWS::StackName'
@@ -2126,10 +2135,10 @@
                     - ;https://
                     - !Ref 'DomainNameAlternates'
       PublicAccessBlockConfiguration:
-        BlockPublicAcls: 'true'
-        BlockPublicPolicy: 'true'
-        IgnorePublicAcls: 'true'
-        RestrictPublicBuckets: 'true'
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
       Tags:
         - Key: aws-web-stacks:stack-name
           Value: !Ref 'AWS::StackName'
@@ -2323,8 +2332,8 @@
   Vpc:
     Properties:
       CidrBlock: !Ref 'VpcCidr'
-      EnableDnsHostnames: 'true'
-      EnableDnsSupport: 'true'
+      EnableDnsHostnames: true
+      EnableDnsSupport: true
       Tags:
         - Key: aws-web-stacks:stack-name
           Value: !Ref 'AWS::StackName'
@@ -2334,3 +2343,4 @@
             - - !Ref 'AWS::StackName'
               - vpc
     Type: AWS::EC2::VPC
+
```