### PR TITLE
Add EksPublicAccessCidrs parameter and enable EKS control plane logging

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,8 @@ Change Log
 * Add ``EksClusterName`` parameter to control name of EKS cluster. If upgrading, set this to STACK_NAME-cluster to match existing name.
 * Drop support for RDS PostgreSQL 9.x
 * Upgrade to troposphere v4.2.0
+* Add ``EksPublicAccessCidrs`` parameter to optionally restrict access to your public Kubernetes API endpoint using CIDR blocks. If defined, both public and private endpoint access enabled as detailed in `API server endpoint access options <https://docs.aws.amazon.com/eks/latest/userguide/cluster-endpoint.html#modify-endpoint-access>`_.
+* Enable ``api``, ``audit``, and ``authenticator`` log types for `EKS control plane logging <https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html>`_.
 
 
 `2.1.2`_ (2022-03-10)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,8 @@ Change Log
 * Upgrade to troposphere v4.2.0
 * Add ``EksPublicAccessCidrs`` parameter to optionally restrict access to your public Kubernetes API endpoint using CIDR blocks. If defined, both public and private endpoint access enabled as detailed in `API server endpoint access options <https://docs.aws.amazon.com/eks/latest/userguide/cluster-endpoint.html#modify-endpoint-access>`_.
 * Enable ``api``, ``audit``, and ``authenticator`` log types for `EKS control plane logging <https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html>`_.
-
+* Allow bastion access to Kubernetes API endpoint
+* Add ``eks.LaunchTemplateSpecification`` to enforce `HttpTokens-based metadata <https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html>`_
 
 `2.1.2`_ (2022-03-10)
 ---------------------

--- a/stack/bastion.py
+++ b/stack/bastion.py
@@ -238,6 +238,18 @@ bastion_security_group_ingress_openvpn = ec2.SecurityGroupIngress(
 if USE_EKS:
     from .eks import cluster
     backend_server_id = GetAtt(cluster, "ClusterSecurityGroupId")
+    # Allow bastion access to Kubernetes API endpoint
+    container_security_group_k8s_ingress = ec2.SecurityGroupIngress(
+        'ContainerSecurityGroupKubernetesBastionIngress',
+        template=template,
+        GroupId=backend_server_id,
+        IpProtocol='tcp',
+        FromPort=443,
+        ToPort=443,
+        SourceSecurityGroupId=Ref(bastion_security_group),
+        Condition=bastion_type_set,
+        Description="Kubernetes API endpoint",
+    )
 else:
     from .security_groups import container_security_group
     backend_server_id = Ref(container_security_group)

--- a/stack/eks.py
+++ b/stack/eks.py
@@ -160,6 +160,8 @@ nodegroup_launch_template = ec2.LaunchTemplate(
         InstanceType=container_instance_type,
         MetadataOptions=ec2.MetadataOptions(
             HttpTokens="required",
+            # Why 3? See note: https://github.com/adamchainz/ec2-metadata#instance-metadata-service-version-2
+            HttpPutResponseHopLimit=3,
         ),
     )
 )

--- a/stack/eks.py
+++ b/stack/eks.py
@@ -109,6 +109,15 @@ cluster = eks.Cluster(
     "EksCluster",
     template=template,
     Name=cluster_name,
+    Logging=eks.Logging(
+        ClusterLogging=eks.ClusterLogging(
+            EnabledTypes=[
+                eks.LoggingTypeConfig(Type="api"),
+                eks.LoggingTypeConfig(Type="audit"),
+                eks.LoggingTypeConfig(Type="authenticator"),
+            ]
+        )
+    ),
     ResourcesVpcConfig=eks.ResourcesVpcConfig(
         SubnetIds=[
             # For load balancers


### PR DESCRIPTION
* Add `EksPublicAccessCidrs` parameter to optionally restrict access to your public Kubernetes API endpoint using CIDR blocks. 
    * If defined, both **public** and **private** endpoint access enabled as detailed in [API server endpoint access options](https://docs.aws.amazon.com/eks/latest/userguide/cluster-endpoint.html#modify-endpoint-access) per this recommendation: 
        > If you restrict access to your public endpoint using CIDR blocks, it is recommended that you also enable private endpoint access so that nodes and Fargate pods (if you use them) can communicate with the cluster. Without the private endpoint enabled, your public access endpoint CIDR sources must include the egress sources from your VPC. For example, if you have a node in a private subnet that communicates to the internet through a NAT Gateway, you will need to add the outbound IP address of the NAT gateway as part of an allowed CIDR block on your public endpoint.
    * Example: <img width="1032" alt="Screen Shot 2023-02-28 at 2 58 12 PM" src="https://user-images.githubusercontent.com/129679/221974977-c187645f-8222-4b38-b1f7-e859e1eaf471.png">

* Enable `api`, `audit`, and `authenticator` log types for [EKS control plane logging](https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html). Configuration after updating: <img width="969" alt="Screen Shot 2023-02-28 at 3 24 49 PM" src="https://user-images.githubusercontent.com/129679/221975066-15ee9f19-4b60-416c-b3f2-a4b9824221d2.png">

* Allow bastion access to Kubernetes API endpoint
* Add `eks.LaunchTemplateSpecification` to enforce [HttpTokens-based metadata](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html)