### PR TITLE
Add Version to EKS Nodegroup Definition

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v3.4.0
+  rev: v6.0.0
   hooks:
     - id: trailing-whitespace
     - id: end-of-file-fixer

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,6 @@ repos:
   hooks:
     - id: isort
 - repo: https://github.com/PyCQA/flake8
-  rev: 6.0.0
+  rev: 7.0.0
   hooks:
     - id: flake8

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+`2.5.0`_ (2025-05-18)
+---------------------
+
+* Adds version mapping to the EKS nodegroup resource in eks.py. This will explicitly bind the EKS nodegroup version to the EKSClusterVersion parameter, eliminating manual post-upgrade nodegroup management.
+
 `2.4.0`_ (2025-09-08)
 ---------------------
 

--- a/stack/eks.py
+++ b/stack/eks.py
@@ -230,6 +230,7 @@ eks.Nodegroup(
     ClusterName=Ref(cluster),
     # The NodeRole must be specified as an ARN.
     NodeRole=GetAtt(container_instance_role, "Arn"),
+    Version=If(use_cluster_version, cluster_version, Ref("AWS::NoValue")),
     LaunchTemplate=eks.LaunchTemplateSpecification(
         Id=Ref(nodegroup_launch_template),
         Version=GetAtt(nodegroup_launch_template, "LatestVersionNumber"),


### PR DESCRIPTION
This PR adds version mapping to the EKS nodegroup resource in eks.py. This will explicitly bind the EKS nodegroup version to the EKSClusterVersion parameter, eliminating the manual post-upgrade node management and allowing the `deploy-cf-stack` playbook to handle both control plane and nodegroup upgrades.